### PR TITLE
ref(config): Renaming service config and moving it to a config dir

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -9,3 +9,6 @@ extend-ignore =
 python_version = 3.12
 strict = True
 ignore_missing_imports = True
+
+[mypy-yaml.*]
+ignore_missing_imports = True

--- a/src/commands/list_dependencies.py
+++ b/src/commands/list_dependencies.py
@@ -24,12 +24,12 @@ def list_dependencies(args: Namespace) -> None:
     """List the dependencies of a service."""
     config = load_service_config(args.service_name)
 
-    dependencies = config.devservices_config.dependencies
+    dependencies = config.service_config.dependencies
 
     if not dependencies:
-        print(f"No dependencies found for {config.devservices_config.service_name}")
+        print(f"No dependencies found for {config.service_config.service_name}")
         return
 
-    print(f"Dependencies of {config.devservices_config.service_name}:")
+    print(f"Dependencies of {config.service_config.service_name}:")
     for dependency_key, dependency_info in dependencies.items():
         print("-", dependency_key, ":", dependency_info.description)

--- a/src/commands/list_dependencies.py
+++ b/src/commands/list_dependencies.py
@@ -4,7 +4,7 @@ from argparse import _SubParsersAction
 from argparse import ArgumentParser
 from argparse import Namespace
 
-from utils.config import load_devservices_config
+from configs.service_config import load_service_config
 
 
 def add_parser(subparsers: _SubParsersAction[ArgumentParser]) -> None:
@@ -22,7 +22,7 @@ def add_parser(subparsers: _SubParsersAction[ArgumentParser]) -> None:
 
 def list_dependencies(args: Namespace) -> None:
     """List the dependencies of a service."""
-    config = load_devservices_config(args.service_name)
+    config = load_service_config(args.service_name)
 
     dependencies = config.devservices_config.dependencies
 

--- a/src/configs/service_config.py
+++ b/src/configs/service_config.py
@@ -51,7 +51,7 @@ class ServiceConfig(BaseModel):
 
 
 class Config(BaseModel):
-    devservices_config: ServiceConfig = Field(alias="x-sentry-service-config")
+    service_config: ServiceConfig = Field(alias="x-sentry-service-config")
 
 
 def load_service_config(service_name: Optional[str]) -> Config:

--- a/src/configs/service_config.py
+++ b/src/configs/service_config.py
@@ -12,7 +12,7 @@ from constants import DOCKER_COMPOSE_FILE_NAME
 from pydantic import BaseModel
 from pydantic import Field
 from pydantic import validator
-from utils.devenv import get_code_root
+from utils.devenv import get_coderoot
 
 
 class Dependency(BaseModel):
@@ -20,7 +20,7 @@ class Dependency(BaseModel):
     link: Optional[str] = None
 
 
-class DevservicesConfig(BaseModel):
+class ServiceConfig(BaseModel):
     version: float
     service_name: str
     dependencies: Dict[str, Dependency]
@@ -51,10 +51,10 @@ class DevservicesConfig(BaseModel):
 
 
 class Config(BaseModel):
-    devservices_config: DevservicesConfig = Field(alias="x-sentry-devservices-config")
+    devservices_config: ServiceConfig = Field(alias="x-sentry-service-config")
 
 
-def load_devservices_config(service_name: Optional[str]) -> Config:
+def load_service_config(service_name: Optional[str]) -> Config:
     """Load the devservices config for a service."""
     if not service_name:
         current_dir = os.getcwd()
@@ -66,8 +66,8 @@ def load_devservices_config(service_name: Optional[str]) -> Config:
                 f"Config file not found in current directory: {config_path}"
             )
     else:
-        code_root = get_code_root()
-        service_path = os.path.join(code_root, service_name)
+        coderoot = get_coderoot()
+        service_path = os.path.join(coderoot, service_name)
         config_path = os.path.join(
             service_path, DEVSERVICES_DIR_NAME, DOCKER_COMPOSE_FILE_NAME
         )

--- a/src/utils/devenv.py
+++ b/src/utils/devenv.py
@@ -9,7 +9,7 @@ from devenv.constants import home
 from devenv.lib.config import read_config
 
 
-def get_code_root() -> str:
+def get_coderoot() -> str:
     config_path = os.path.join(home, ".config", "sentry-devenv", "config.ini")
     try:
         devenv_config: ConfigParser = read_config(config_path)


### PR DESCRIPTION
* Renamed devservices config to service config to be clearer.
* Moved the service config to a new configs directory to improve organization.
* Added mypy ignore for pyyaml nonsense (https://github.com/python/mypy/issues/10632).
* Renamed code_root to coderoot.