### PR TITLE
Remove pydantic

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,7 +21,6 @@ repos:
         additional_dependencies:
           - "pytest"
           - "types-PyYAML"
-          - "pydantic-settings"
         language_version: python3.12
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.9.0.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 --index-url https://pypi.devinfra.sentry.io/simple
 pyyaml==6.0.1
 sentry-devenv==1.8.0
-pydantic==2.8.2

--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     packages=find_packages(where="src"),
     package_dir={"": "src"},
     include_package_data=True,
-    install_requires=["pyyaml", "sentry-devenv", "pydantic"],
+    install_requires=["pyyaml", "sentry-devenv"],
     extras_requires={
         "dev": ["black", "mypy", "pre-commit", "pytest", "types-PyYAML"],
     },

--- a/src/configs/service_config.py
+++ b/src/configs/service_config.py
@@ -1,57 +1,48 @@
 from __future__ import annotations
 
 import os
+from dataclasses import dataclass
 from typing import Dict
 from typing import List
 from typing import Optional
-from typing import Union
 
 import yaml
 from constants import DEVSERVICES_DIR_NAME
 from constants import DOCKER_COMPOSE_FILE_NAME
-from pydantic import BaseModel
-from pydantic import Field
-from pydantic import validator
 from utils.devenv import get_coderoot
 
 
-class Dependency(BaseModel):
+@dataclass
+class Dependency:
     description: str
     link: Optional[str] = None
 
 
-class ServiceConfig(BaseModel):
+@dataclass
+class ServiceConfig:
     version: float
     service_name: str
     dependencies: Dict[str, Dependency]
     modes: Dict[str, List[str]]
 
-    @validator("version")
-    def check_version(cls, version: float) -> float:
-        if version != 0.1:
-            raise ValueError("Version must be 0.1")
-        return version
+    def __post_init__(self) -> None:
+        self._validate()
 
-    @validator("modes")
-    def check_modes(
-        cls,
-        modes: Dict[str, List[str]],
-        values: Dict[str, Union[float, str, Dict[str, Dependency]]],
-    ) -> Dict[str, List[str]]:
-        dependencies = values.get("dependencies", {})
-        if not isinstance(dependencies, dict):
-            raise ValueError("Dependencies must be a dictionary")
-        for mode, services in modes.items():
+    def _validate(self) -> None:
+        if self.version != 0.1:
+            raise ValueError("Version must be 0.1")
+
+        for mode, services in self.modes.items():
             for service in services:
-                if service not in dependencies:
+                if service not in self.dependencies:
                     raise ValueError(
                         f"Service '{service}' in mode '{mode}' is not defined in dependencies"
                     )
-        return modes
 
 
-class Config(BaseModel):
-    service_config: ServiceConfig = Field(alias="x-sentry-service-config")
+@dataclass
+class Config:
+    service_config: ServiceConfig
 
 
 def load_service_config(service_name: Optional[str]) -> Config:
@@ -78,7 +69,19 @@ def load_service_config(service_name: Optional[str]) -> Config:
     with open(config_path, "r") as stream:
         try:
             config = yaml.safe_load(stream)
-            return Config(**config)
+            service_config_data = config.get("x-sentry-devservices-config", {})
+            dependencies = {
+                key: Dependency(**value)
+                for key, value in service_config_data.get("dependencies", {}).items()
+            }
+            service_config = ServiceConfig(
+                version=service_config_data.get("version"),
+                service_name=service_config_data.get("service_name"),
+                dependencies=dependencies,
+                modes=service_config_data.get("modes", {}),
+            )
+
+            return Config(service_config=service_config)
         except FileNotFoundError as fnf:
             raise FileNotFoundError(f"Config file not found: {config_path}") from fnf
         except yaml.YAMLError as yml_error:


### PR DESCRIPTION
This removes pydantic in favor of [dataclasses](https://docs.python.org/3/library/dataclasses.html)

Reasons why:
- Pydantic is known to be slow
- we don't need the benefits Pydantic gives for complex data models
- one less dependency