### PR TITLE
chore(service-config): Refactoring service config loading

### DIFF
--- a/src/commands/list_dependencies.py
+++ b/src/commands/list_dependencies.py
@@ -6,8 +6,8 @@ from argparse import Namespace
 from typing import Optional
 
 from configs.service_config import load_service_config
+from configs.service_config import ServiceConfig
 from services import find_matching_service
-from services import Service
 
 
 def add_parser(subparsers: _SubParsersAction[ArgumentParser]) -> None:
@@ -27,16 +27,20 @@ def list_dependencies(args: Namespace) -> None:
     """List the dependencies of a service."""
     service_name = args.service_name
 
-    service: Optional[Service] = None
+    service_config: Optional[ServiceConfig] = None
     if service_name is not None:
         try:
-            service = find_matching_service(service_name)
+            service_config = find_matching_service(service_name).service_config
+        except Exception as e:
+            print(e)
+            return
+    else:
+        try:
+            service_config = load_service_config()
         except Exception as e:
             print(e)
             return
 
-    # Note: If no service name is provided, the current directory is assumed to be the location of the service
-    service_config = load_service_config(service)
     dependencies = service_config.dependencies
 
     if not dependencies:

--- a/src/configs/service_config.py
+++ b/src/configs/service_config.py
@@ -5,14 +5,10 @@ from dataclasses import dataclass
 from typing import Dict
 from typing import List
 from typing import Optional
-from typing import TYPE_CHECKING
 
 import yaml
 from constants import DEVSERVICES_DIR_NAME
 from constants import DOCKER_COMPOSE_FILE_NAME
-
-if TYPE_CHECKING:
-    from services import Service
 
 
 @dataclass
@@ -80,11 +76,6 @@ def load_service_config_from_file(repo_path: str) -> ServiceConfig:
             ) from yml_error
 
 
-def load_service_config(service: Optional[Service] = None) -> ServiceConfig:
-    """Load the service config for a repo."""
-    if service is None:
-        current_dir = os.getcwd()
-        return load_service_config_from_file(current_dir)
-    if not isinstance(service.service_config, ServiceConfig):
-        raise TypeError("service_config must be of type ServiceConfig")
-    return service.service_config
+def load_service_config() -> ServiceConfig:
+    """Load the service config for the current directory."""
+    return load_service_config_from_file(os.getcwd())

--- a/src/services.py
+++ b/src/services.py
@@ -3,12 +3,9 @@ from __future__ import annotations
 import os
 from dataclasses import dataclass
 from typing import List
-from typing import TYPE_CHECKING
 
+from configs.service_config import ServiceConfig
 from utils.devenv import get_coderoot
-
-if TYPE_CHECKING:
-    from configs.service_config import ServiceConfig
 
 
 @dataclass


### PR DESCRIPTION
Removing circular dependency by refactoring how we handle loading the config, simplifying the logic in the process. Now instead of passing an optional service into load_service_config, we pass nothing, but only if a service name is not provided (meaning the user is running the command from a repo directly).