### PR TITLE
fix(cli): Added status when service isn't running

### DIFF
--- a/src/commands/status.py
+++ b/src/commands/status.py
@@ -73,11 +73,15 @@ def status(args: Namespace) -> None:
     service_config_file_path = os.path.join(
         service.repo_path, DEVSERVICES_DIR_NAME, DOCKER_COMPOSE_FILE_NAME
     )
-    output = f"Service: {service.name}\n\n"
     mode_dependencies = " ".join(modes[mode_to_view])
     status_json = run_docker_compose_command(
         f"-f {service_config_file_path} ps {mode_dependencies} --format json"
     ).stdout
+    # If the service is not running, the status_json will be empty
+    if not status_json:
+        print(f"{service.name} is not running")
+        return
+    output = f"Service: {service.name}\n\n"
     output += format_status_output(status_json)
     output += "=" * LINE_LENGTH
     sys.stdout.write(output + "\n")


### PR DESCRIPTION
Rather than printing an empty status, this change informs the user that the service is not running. I can't think of any cases where the `status_json` would be empty when the service is running, but if there are any, let me know.