### PR TITLE
ref(config): Adding more validation and tests for service config

### DIFF
--- a/src/configs/service_config.py
+++ b/src/configs/service_config.py
@@ -13,6 +13,9 @@ from exceptions import ConfigParseError
 from exceptions import ConfigValidationError
 
 
+VALID_VERSIONS = [0.1]
+
+
 @dataclass
 class Dependency:
     description: str
@@ -30,7 +33,10 @@ class ServiceConfig:
         self._validate()
 
     def _validate(self) -> None:
-        if self.version != 0.1:
+        if not self.version:
+            raise ConfigValidationError("Version is required in service config")
+
+        if self.version not in VALID_VERSIONS:
             raise ConfigValidationError(
                 f"Invalid version '{self.version}' in service config"
             )
@@ -38,7 +44,12 @@ class ServiceConfig:
         if not self.service_name:
             raise ConfigValidationError("Service name is required in service config")
 
+        if "default" not in self.modes:
+            raise ConfigValidationError("Default mode is required in service config")
+
         for mode, services in self.modes.items():
+            if not isinstance(services, list):
+                raise ConfigValidationError(f"Services in mode '{mode}' must be a list")
             for service in services:
                 if service not in self.dependencies:
                     raise ConfigValidationError(
@@ -55,24 +66,32 @@ def load_service_config_from_file(repo_path: str) -> ServiceConfig:
     with open(config_path, "r") as stream:
         try:
             config = yaml.safe_load(stream)
-            service_config_data = config.get("x-sentry-service-config", {})
+        except yaml.YAMLError as yml_error:
+            raise ConfigParseError(
+                f"Error parsing config file: {yml_error}"
+            ) from yml_error
+
+        if "x-sentry-service-config" not in config:
+            raise ConfigParseError(
+                "Config file does not contain 'x-sentry-service-config' key"
+            )
+        service_config_data = config.get("x-sentry-service-config")
+
+        try:
             dependencies = {
                 key: Dependency(**value)
                 for key, value in service_config_data.get("dependencies", {}).items()
             }
-            service_config = ServiceConfig(
-                version=service_config_data.get("version"),
-                service_name=service_config_data.get("service_name"),
-                dependencies=dependencies,
-                modes=service_config_data.get("modes", {}),
-            )
-
-            return service_config
-        except FileNotFoundError as fnf_error:
-            raise ConfigNotFoundError(
-                f"Config file not found: {config_path}"
-            ) from fnf_error
-        except yaml.YAMLError as yml_error:
+        except TypeError as type_error:
             raise ConfigParseError(
-                f"Error parsing config file: {config_path}"
-            ) from yml_error
+                f"Error parsing service dependencies: {type_error}"
+            ) from type_error
+
+        service_config = ServiceConfig(
+            version=service_config_data.get("version"),
+            service_name=service_config_data.get("service_name"),
+            dependencies=dependencies,
+            modes=service_config_data.get("modes", {}),
+        )
+
+        return service_config

--- a/tests/configs/test_service_config.py
+++ b/tests/configs/test_service_config.py
@@ -7,6 +7,7 @@ import pytest
 import yaml
 from configs.service_config import load_service_config_from_file
 from exceptions import ConfigNotFoundError
+from exceptions import ConfigParseError
 from exceptions import ConfigValidationError
 
 
@@ -39,6 +40,19 @@ def create_config_file(tmp_path: Path, config: dict[str, dict[str, object]]) -> 
             },
             {"default": ["example-dependency-1", "example-dependency-2"]},
         ),
+        (
+            "example-service",
+            {
+                "example-dependency-1": {
+                    "description": "Example dependency 1",
+                    "link": "https://example.com",
+                },
+                "example-dependency-2": {
+                    "description": "Example dependency 2",
+                },
+            },
+            {"default": ["example-dependency-1"], "custom": ["example-dependency-2"]},
+        ),
     ],
 )
 def test_load_service_config_from_file(
@@ -69,6 +83,25 @@ def test_load_service_config_from_file(
     }
 
 
+def test_load_service_config_from_file_no_dependencies(tmp_path: Path) -> None:
+    config = {
+        "x-sentry-service-config": {
+            "version": 0.1,
+            "service_name": "example-service",
+            "modes": {"default": []},
+        }
+    }
+    create_config_file(tmp_path, config)
+
+    service_config = load_service_config_from_file(tmp_path)
+    assert asdict(service_config) == {
+        "version": 0.1,
+        "service_name": "example-service",
+        "dependencies": {},
+        "modes": {"default": []},
+    }
+
+
 def test_load_service_config_from_file_missing_config(tmp_path: Path) -> None:
     with pytest.raises(ConfigNotFoundError) as e:
         load_service_config_from_file(tmp_path)
@@ -94,6 +127,22 @@ def test_load_service_config_from_file_invalid_version(tmp_path: Path) -> None:
     with pytest.raises(ConfigValidationError) as e:
         load_service_config_from_file(tmp_path)
     assert str(e.value) == "Invalid version '0.2' in service config"
+
+
+def test_load_service_config_from_file_missing_version(tmp_path: Path) -> None:
+    config = {
+        "x-sentry-service-config": {
+            "dependencies": {
+                "example-dependency": {"description": "Example dependency"}
+            },
+            "modes": {"default": ["example-dependency"]},
+        }
+    }
+    create_config_file(tmp_path, config)
+
+    with pytest.raises(ConfigValidationError) as e:
+        load_service_config_from_file(tmp_path)
+    assert str(e.value) == "Version is required in service config"
 
 
 def test_load_service_config_from_file_missing_service_name(tmp_path: Path) -> None:
@@ -131,4 +180,151 @@ def test_load_service_config_from_file_invalid_dependency(tmp_path: Path) -> Non
     assert (
         str(e.value)
         == "Service 'unknown-dependency' in mode 'default' is not defined in dependencies"
+    )
+
+
+def test_load_service_config_from_file_missing_default_mode(tmp_path: Path) -> None:
+    config = {
+        "x-sentry-service-config": {
+            "version": 0.1,
+            "service_name": "example-service",
+            "dependencies": {
+                "example-dependency": {"description": "Example dependency"}
+            },
+            "modes": {"custom": ["example-dependency"]},
+        }
+    }
+    create_config_file(tmp_path, config)
+
+    with pytest.raises(ConfigValidationError) as e:
+        load_service_config_from_file(tmp_path)
+    assert str(e.value) == "Default mode is required in service config"
+
+
+def test_load_service_config_from_file_no_modes(tmp_path: Path) -> None:
+    config = {
+        "x-sentry-service-config": {
+            "version": 0.1,
+            "service_name": "example-service",
+            "dependencies": {
+                "example-dependency": {"description": "Example dependency"}
+            },
+        }
+    }
+    create_config_file(tmp_path, config)
+
+    with pytest.raises(ConfigValidationError) as e:
+        load_service_config_from_file(tmp_path)
+    assert str(e.value) == "Default mode is required in service config"
+
+
+def test_load_service_config_from_file_invalid_dependencies(tmp_path: Path) -> None:
+    config = {
+        "x-sentry-service-config": {
+            "version": 0.1,
+            "service_name": "example-service",
+            "dependencies": {
+                "example-dependency": {
+                    "description": "Example dependency",
+                    "unknown": "key",
+                }
+            },
+            "modes": {"default": ["example-dependency"]},
+        }
+    }
+    create_config_file(tmp_path, config)
+
+    with pytest.raises(ConfigParseError) as e:
+        load_service_config_from_file(tmp_path)
+    assert (
+        str(e.value)
+        == "Error parsing service dependencies: Dependency.__init__() got an unexpected keyword argument 'unknown'"
+    )
+
+
+def test_load_service_config_from_file_invalid_modes(tmp_path: Path) -> None:
+    config = {
+        "x-sentry-service-config": {
+            "version": 0.1,
+            "service_name": "example-service",
+            "dependencies": {
+                "example-dependency": {"description": "Example dependency"}
+            },
+            "modes": {
+                "default": ["example-dependency"],
+                "custom": "example-dependency",
+            },
+        }
+    }
+    create_config_file(tmp_path, config)
+
+    with pytest.raises(ConfigValidationError) as e:
+        load_service_config_from_file(tmp_path)
+    assert str(e.value) == "Services in mode 'custom' must be a list"
+
+
+def test_load_service_config_from_file_no_x_sentry_service_config(
+    tmp_path: Path,
+) -> None:
+    config = {
+        "x-not-sentry-service-config": {
+            "version": 0.1,
+            "service_name": "example-service",
+            "dependencies": {
+                "example-dependency": {"description": "Example dependency"}
+            },
+            "modes": {"default": ["example-dependency"]},
+        }
+    }
+    create_config_file(tmp_path, config)
+
+    with pytest.raises(ConfigParseError) as e:
+        load_service_config_from_file(tmp_path)
+    assert str(e.value) == "Config file does not contain 'x-sentry-service-config' key"
+
+
+def test_load_service_config_from_file_invalid_yaml(tmp_path: Path) -> None:
+    config = """x-sentry-service-config
+    version: 0.1
+    service_name: "example-service"
+    dependencies:
+        example-dependency:
+            description: "Example dependency"
+    modes:
+        default: ["example-dependency"]"""
+    devservices_dir = Path(tmp_path, "devservices")
+    devservices_dir.mkdir(parents=True, exist_ok=True)
+    tmp_file = Path(devservices_dir, "docker-compose.yml")
+    with tmp_file.open("w") as f:
+        f.write(config)
+
+    with pytest.raises(ConfigParseError) as e:
+        load_service_config_from_file(tmp_path)
+    assert (
+        str(e.value)
+        == f"Error parsing config file: mapping values are not allowed here\n  in \"{tmp_path / 'devservices' / 'docker-compose.yml'}\", line 2, column 12"
+    )
+
+
+def test_load_service_config_from_file_invalid_yaml_tag(tmp_path: Path) -> None:
+    config = """x-sentry-service-config:
+    version: 0.1
+    service_name: "example-service"
+    dependencies:
+        example-dependency:
+            description: "Example dependency"
+            link: !!invalid_tag "https://example.com"
+    modes:
+        default: ["example-dependency"]"""
+    devservices_dir = Path(tmp_path, "devservices")
+    devservices_dir.mkdir(parents=True, exist_ok=True)
+    tmp_file = Path(devservices_dir, "docker-compose.yml")
+    with tmp_file.open("w") as f:
+        f.write(config)
+
+    with pytest.raises(ConfigParseError) as e:
+        load_service_config_from_file(tmp_path)
+    assert (
+        str(e.value)
+        == f"Error parsing config file: could not determine a constructor for the tag 'tag:yaml.org,2002:invalid_tag'\n  in \"{tmp_path / 'devservices' / 'docker-compose.yml'}\", line 7, column 19"
     )


### PR DESCRIPTION
* Splitting up try excepts to limit the amount of code in the try statements as it is a [best practice](https://peps.python.org/pep-0008/#:~:text=Additionally%2C%20for%20all%20try/except%20clauses%2C%20limit%20the%20try%20clause%20to%20the%20absolute%20minimum%20amount%20of%20code%20necessary.%20Again%2C%20this%20avoids%20masking%20bugs%3A)
* Removing redundant error handling
* Adding more error handling where necessary for type errors related to dependencies
* Adding some general validation to catch more issues with service configs
* Improving test coverage