### PR TITLE
chore(typing): Switching to modern typing practices

### DIFF
--- a/src/configs/service_config.py
+++ b/src/configs/service_config.py
@@ -2,8 +2,6 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import Dict
-from typing import List
 
 import yaml
 from constants import DEVSERVICES_DIR_NAME
@@ -23,8 +21,8 @@ class Dependency:
 class ServiceConfig:
     version: float
     service_name: str
-    dependencies: Dict[str, Dependency]
-    modes: Dict[str, List[str]]
+    dependencies: dict[str, Dependency]
+    modes: dict[str, list[str]]
 
     def __post_init__(self) -> None:
         self._validate()

--- a/src/utils/services.py
+++ b/src/utils/services.py
@@ -2,7 +2,6 @@ from __future__ import annotations
 
 import os
 from dataclasses import dataclass
-from typing import List
 
 from configs.service_config import ServiceConfig
 from exceptions import ConfigNotFoundError
@@ -19,7 +18,7 @@ class Service:
     config: ServiceConfig
 
 
-def get_local_services(coderoot: str) -> List[Service]:
+def get_local_services(coderoot: str) -> list[Service]:
     """Get a list of services in the coderoot."""
     from configs.service_config import load_service_config_from_file
 


### PR DESCRIPTION
Importing list, dict, ect from typing is no longer required in recent versions of python.