### PR TITLE
fix(cli): Adding atexit handler to avoid sending sentry logs to console

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import argparse
+import atexit
 
 import sentry_sdk
 from commands import list_dependencies
@@ -19,6 +20,11 @@ sentry_sdk.init(
     enable_tracing=True,
     integrations=[ArgvIntegration()],
 )
+
+
+@atexit.register
+def cleanup() -> None:
+    sentry_sdk.flush()
 
 
 def main() -> None:


### PR DESCRIPTION
Removes the "Sentry is attempting to send 2 pending events" messages.