### PR TITLE
feat(release): Build and upload binary

### DIFF
--- a/.craft.yml
+++ b/.craft.yml
@@ -7,3 +7,7 @@ targets:
   - name: pypi
   - name: sentry-pypi
     internalPypiRepo: getsentry/pypi
+
+requireNames:
+  - /^devservices-darwin$/
+  - /^devservices-linux$/

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,6 +44,9 @@ jobs:
         with:
           python-version: 3.12
 
+      - name: Install pyoxidizer
+        run: pip install pyoxidizer==0.24.0
+
       - name: Install dev requirements
         run: pip install -r requirements-dev.txt
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,8 +44,8 @@ jobs:
         with:
           python-version: 3.12
 
-      - name: Install pyoxidizer
-        run: pip install pyoxidizer==0.24.0
+      - name: Install dev requirements
+        run: pip install -r requirements-dev.txt
 
       - name: Generate metadata
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,8 +4,6 @@ on:
     branches:
       - main
       - release/**
-  # delete after verifying CI
-  pull_request:
 
 jobs:
   dist:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,3 +23,38 @@ jobs:
         with:
           name: ${{ github.sha }}
           path: dist/*
+
+    binary:
+      name: Build on ${{ matrix.os }}
+      runs-on: ${{ matrix.os }}
+      strategy:
+        matrix:
+          os: [ubuntu-22.04, macos-14]
+          include:
+            - os: ubuntu-latest
+              asset_name: devservices-linux
+            - os: macos-latest
+              asset_name: devservices-macos
+
+      steps:
+        - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+        - uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
+          with:
+            python-version: 3.12
+
+        - name: Install pyoxidizer
+          run: pip install pyoxidizer==0.24.0
+
+        - name: Build binary
+          run: pyoxidizer build --release
+
+        - name: Locate binary
+          id: locate_binary
+          shell: bash
+          run: echo "::set-output name=binary_path::$(find build -name devservices -type f)"
+
+        - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+          with:
+            name: ${{ github.sha }}
+            path: ${{ steps.locate_binary.outputs.binary_path }}
+

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,7 +65,7 @@ jobs:
         id: locate_binary
         shell: bash
         run: |
-          echo "binary_path=$(find build -name devservices -type f)" >> $GITHUB_OUTPUT
+          BINARY_PATH=$(find build -name devservices -type f)
           mkdir -p binaries
           cp $BINARY_PATH binaries/${{ matrix.asset_name }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -106,6 +106,6 @@ jobs:
           name: ${{ github.sha }}
           path: |
             dist/*
-            devservices-linux
-            devservices-darwin
+            binaries/devservices-darwin
+            binaries/devservices-linux
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -76,7 +76,7 @@ jobs:
   upload-artifacts:
     name: Upload build artifacts
     needs: [dist, binary]
-    if: github.event_name != 'pull_request'
+    # if: github.event_name != 'pull_request'
     steps:
       - name: Restore dist cache
         uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,8 @@ on:
     branches:
       - main
       - release/**
+  # delete after verifying CI
+  pull_request:
 
 jobs:
   dist:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -57,7 +57,6 @@ jobs:
 
       - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
-          name: ${{ github.sha }}
-          path: ${{ steps.locate_binary.outputs.binary_path }}
           name: ${{ matrix.asset_name }}
+          path: ${{ steps.locate_binary.outputs.binary_path }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,8 +27,8 @@ jobs:
       - name: Cache dist
         uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
         with:
-          path: dist/*
-          key: devservices-dist-files
+          path: dist
+          key: devservices-dist-${{ github.sha }}
 
   binary:
     name: Build on ${{ matrix.os }}
@@ -70,7 +70,7 @@ jobs:
         uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
         with:
           path: ${{ steps.locate_binary.outputs.binary_path }}
-          key: ${{ matrix.asset_name }}
+          key: ${{ matrix.asset_name }}-${{ github.sha }}
 
 
   upload-artifacts:
@@ -83,19 +83,19 @@ jobs:
         uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
         with:
           path: dist
-          key: devservices-dist-files
+          key: devservices-dist-${{ github.sha }}
 
       - name: Restore Linux binary cache
         uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
         with:
           path: devservices-linux
-          key: devservices-linux
+          key: devservices-linux-${{ github.sha }}
 
       - name: Restore macOS binary cache
         uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
         with:
           path: devservices-darwin
-          key: devservices-darwin
+          key: devservices-darwin-${{ github.sha }}
 
       - name: Upload combined artifacts
         uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,37 +26,37 @@ jobs:
           name: ${{ github.sha }}
           path: dist/*
 
-    binary:
-      name: Build on ${{ matrix.os }}
-      runs-on: ${{ matrix.os }}
-      strategy:
-        matrix:
-          os: [ubuntu-22.04, macos-14]
-          include:
-            - os: ubuntu-latest
-              asset_name: devservices-linux
-            - os: macos-latest
-              asset_name: devservices-macos
+  binary:
+    name: Build on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-22.04, macos-14]
+        include:
+          - os: ubuntu-22.04
+            asset_name: devservices-linux
+          - os: macos-14
+            asset_name: devservices-macos
 
-      steps:
-        - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
-        - uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
-          with:
-            python-version: 3.12
+    steps:
+      - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+      - uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
+        with:
+          python-version: 3.12
 
-        - name: Install pyoxidizer
-          run: pip install pyoxidizer==0.24.0
+      - name: Install pyoxidizer
+        run: pip install pyoxidizer==0.24.0
 
-        - name: Build binary
-          run: pyoxidizer build --release
+      - name: Build binary
+        run: pyoxidizer build --release
 
-        - name: Locate binary
-          id: locate_binary
-          shell: bash
-          run: echo "::set-output name=binary_path::$(find build -name devservices -type f)"
+      - name: Locate binary
+        id: locate_binary
+        shell: bash
+        run: echo "::set-output name=binary_path::$(find build -name devservices -type f)"
 
-        - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
-          with:
-            name: ${{ github.sha }}
-            path: ${{ steps.locate_binary.outputs.binary_path }}
+      - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+        with:
+          name: ${{ github.sha }}
+          path: ${{ steps.locate_binary.outputs.binary_path }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -9,7 +9,7 @@ on:
 jobs:
   dist:
     name: Create Distribution
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -75,6 +75,7 @@ jobs:
 
   upload-artifacts:
     name: Upload build artifacts
+    runs-on: ubuntu-22.04
     needs: [dist, binary]
     # if: github.event_name != 'pull_request'
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
         with:
-          python-version: 3.12
+          python-version: 3.11
 
       - name: Install pyoxidizer
         run: pip install pyoxidizer==0.24.0
@@ -53,7 +53,7 @@ jobs:
       - name: Locate binary
         id: locate_binary
         shell: bash
-        run: echo "::set-output name=binary_path::$(find build -name devservices -type f)"
+        run: echo "binary_path=$(find build -name devservices -type f)" >> $GITHUB_OUTPUT
 
       - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -47,6 +47,11 @@ jobs:
       - name: Install pyoxidizer
         run: pip install pyoxidizer==0.24.0
 
+      - name: Generate metadata
+        run: |
+          pip install build
+          python -m build --sdist --no-isolation
+
       - name: Build binary
         run: pyoxidizer build --release
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -36,7 +36,7 @@ jobs:
           - os: ubuntu-22.04
             asset_name: devservices-linux
           - os: macos-14
-            asset_name: devservices-macos
+            asset_name: devservices-darwin
 
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
@@ -59,4 +59,5 @@ jobs:
         with:
           name: ${{ github.sha }}
           path: ${{ steps.locate_binary.outputs.binary_path }}
+          name: ${{ ${{ matrix.asset_name }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Generate metadata
         run: |
-          pip install build
+          pip install build wheel
           python -m build --sdist --no-isolation
 
       - name: Build binary

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,13 +14,17 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
       - uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
         with:
           python-version: 3.12
+
+      - name: Install dev requirements
+        run: pip install -r requirements-dev.txt
+
       - name: "Prepare Artifacts"
-        run: |
-          pip install build
-          python -m build
+        run: python -m build
+
       - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
         with:
           name: ${{ github.sha }}
@@ -40,6 +44,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
+
       - uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
         with:
           python-version: 3.12
@@ -51,9 +56,7 @@ jobs:
         run: pip install -r requirements-dev.txt
 
       - name: Generate metadata
-        run: |
-          pip install build wheel
-          python -m build --sdist --no-isolation
+        run: python -m build --sdist --no-isolation
 
       - name: Build binary
         run: pyoxidizer build --release

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Cache dist
         uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
         with:
-          path: dist
+          path: dist/*
           key: devservices-dist-files
 
   binary:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,7 +42,7 @@ jobs:
       - uses: actions/checkout@692973e3d937129bcbf40652eb9f2f61becf3332 # v4.1.7
       - uses: actions/setup-python@39cd14951b08e74b54015e9e001cdefcf80e669f # v5.1.1
         with:
-          python-version: 3.11
+          python-version: 3.12
 
       - name: Install pyoxidizer
         run: pip install pyoxidizer==0.24.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,5 +59,5 @@ jobs:
         with:
           name: ${{ github.sha }}
           path: ${{ steps.locate_binary.outputs.binary_path }}
-          name: ${{ ${{ matrix.asset_name }}
+          name: ${{ matrix.asset_name }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -80,7 +80,7 @@ jobs:
     name: Upload build artifacts
     runs-on: ubuntu-22.04
     needs: [dist, binary]
-    # if: github.event_name != 'pull_request'
+    if: github.event_name != 'pull_request'
     steps:
       - name: Restore dist cache
         uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
@@ -106,6 +106,5 @@ jobs:
           name: ${{ github.sha }}
           path: |
             dist/*
-            binaries/devservices-darwin
-            binaries/devservices-linux
+            binaries/*
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,12 +64,15 @@ jobs:
       - name: Locate binary
         id: locate_binary
         shell: bash
-        run: echo "binary_path=$(find build -name devservices -type f)" >> $GITHUB_OUTPUT
+        run: |
+          echo "binary_path=$(find build -name devservices -type f)" >> $GITHUB_OUTPUT
+          mkdir -p binaries
+          cp $BINARY_PATH binaries/${{ matrix.asset_name }}
 
       - name: Cache binary
         uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
         with:
-          path: ${{ steps.locate_binary.outputs.binary_path }}
+          path: binaries/${{ matrix.asset_name }}
           key: ${{ matrix.asset_name }}-${{ github.sha }}
 
 
@@ -88,13 +91,13 @@ jobs:
       - name: Restore Linux binary cache
         uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
         with:
-          path: devservices-linux
+          path: binaries/devservices-linux
           key: devservices-linux-${{ github.sha }}
 
       - name: Restore macOS binary cache
         uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
         with:
-          path: devservices-darwin
+          path: binaries/devservices-darwin
           key: devservices-darwin-${{ github.sha }}
 
       - name: Upload combined artifacts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,6 +4,7 @@ on:
     branches:
       - main
       - release/**
+  pull_request:
 
 jobs:
   dist:
@@ -23,10 +24,11 @@ jobs:
       - name: "Prepare Artifacts"
         run: python -m build
 
-      - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+      - name: Cache dist
+        uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
         with:
-          name: ${{ github.sha }}
-          path: dist/*
+          path: dist
+          key: devservices-dist-files
 
   binary:
     name: Build on ${{ matrix.os }}
@@ -64,8 +66,42 @@ jobs:
         shell: bash
         run: echo "binary_path=$(find build -name devservices -type f)" >> $GITHUB_OUTPUT
 
-      - uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+      - name: Cache binary
+        uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
         with:
-          name: ${{ matrix.asset_name }}
           path: ${{ steps.locate_binary.outputs.binary_path }}
+          key: ${{ matrix.asset_name }}
+
+
+  upload-artifacts:
+    name: Upload build artifacts
+    needs: [dist, binary]
+    if: github.event_name != 'pull_request'
+    steps:
+      - name: Restore dist cache
+        uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
+        with:
+          path: dist
+          key: devservices-dist-files
+
+      - name: Restore Linux binary cache
+        uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
+        with:
+          path: devservices-linux
+          key: devservices-linux
+
+      - name: Restore macOS binary cache
+        uses: actions/cache@ab5e6d0c87105b4c9c2047343972218f562e4319 # v4.0.1
+        with:
+          path: devservices-darwin
+          key: devservices-darwin
+
+      - name: Upload combined artifacts
+        uses: actions/upload-artifact@50769540e7f4bd5e21e526ee35c689e35e0d6874 # v4.4.0
+        with:
+          name: ${{ github.sha }}
+          path: |
+            dist/*
+            devservices-linux
+            devservices-darwin
 

--- a/devservices/main.py
+++ b/devservices/main.py
@@ -30,7 +30,8 @@ def cleanup() -> None:
 
 def main() -> None:
     parser = argparse.ArgumentParser(
-        description="DevServices CLI tool for managing Docker Compose services."
+        prog="devservices",
+        description="DevServices CLI tool for managing Docker Compose services.",
     )
     parser.add_argument(
         "--version", action="version", version=metadata.version("devservices")

--- a/pyoxidizer.bzl
+++ b/pyoxidizer.bzl
@@ -64,6 +64,7 @@ def make_exe():
 
     # Invoke `pip install` using a requirements file and add the collected resources
     # to our binary.
+    exe.add_python_resources(exe.pip_install(["."], optimize=True))
     exe.add_python_resources(exe.pip_install(["-r", "requirements.txt"]))
 
 

--- a/pyoxidizer.bzl
+++ b/pyoxidizer.bzl
@@ -1,0 +1,102 @@
+# This file defines how PyOxidizer application building and packaging is
+# performed. See PyOxidizer's documentation at
+# https://gregoryszorc.com/docs/pyoxidizer/stable/pyoxidizer.html for details
+# of this configuration file format.
+
+# Configuration files consist of functions which define build "targets."
+# This function creates a Python executable and installs it in a destination
+# directory.
+def make_exe():
+    # Obtain the default PythonDistribution for our build target. We link
+    # this distribution into our produced executable and extract the Python
+    # standard library from it.
+    dist = default_python_distribution()
+
+    # This function creates a `PythonPackagingPolicy` instance, which
+    # influences how executables are built and how resources are added to
+    # the executable. You can customize the default behavior by assigning
+    # to attributes and calling functions.
+    policy = dist.make_python_packaging_policy()
+
+    # Resources are loaded from "in-memory" or "filesystem-relative" paths.
+    # The locations to attempt to add resources to are defined by the
+    # `resources_location` and `resources_location_fallback` attributes.
+    # The former is the first/primary location to try and the latter is
+    # an optional fallback.
+
+    # Use in-memory location for adding resources by default.
+    policy.resources_location = "in-memory"
+
+    # Attempt to add resources relative to the built binary when
+    # `resources_location` fails.
+    policy.resources_location_fallback = "filesystem-relative:prefix"
+
+    # This variable defines the configuration of the embedded Python
+    # interpreter. By default, the interpreter will run a Python REPL
+    # using settings that are appropriate for an "isolated" run-time
+    # environment.
+    #
+    # The configuration of the embedded Python interpreter can be modified
+    # by setting attributes on the instance. Some of these are
+    # documented below.
+    python_config = dist.make_python_interpreter_config()
+
+    # Set initial value for `sys.path`. If the string `$ORIGIN` exists in
+    # a value, it will be expanded to the directory of the built executable.
+    python_config.module_search_paths = ["$ORIGIN/devservices"]
+
+    # Run a Python module as __main__ when the interpreter starts.
+    python_config.run_module = "devservices.main"
+
+    # Produce a PythonExecutable from a Python distribution, embedded
+    # resources, and other options. The returned object represents the
+    # standalone executable that will be built.
+    exe = dist.to_python_executable(
+        name="devservices",
+
+        # If no argument passed, the default `PythonPackagingPolicy` for the
+        # distribution is used.
+        packaging_policy=policy,
+
+        # If no argument passed, the default `PythonInterpreterConfig` is used.
+        config=python_config,
+    )
+
+    # Invoke `pip install` using a requirements file and add the collected resources
+    # to our binary.
+    exe.add_python_resources(exe.pip_install(["-r", "requirements.txt"]))
+
+
+    # Read Python files from a local directory and add them to our embedded
+    # context, taking just the resources belonging to the `foo` and `bar`
+    # Python packages.
+    exe.add_python_resources(exe.read_package_root(
+        path=".",
+        packages=["devservices"],
+    ))
+
+    # Return our `PythonExecutable` instance so it can be built and
+    # referenced by other consumers of this target.
+    return exe
+
+def make_embedded_resources(exe):
+    return exe.to_embedded_resources()
+
+def make_install(exe):
+    # Create an object that represents our installed application file layout.
+    files = FileManifest()
+
+    # Add the generated executable to our install layout in the root directory.
+    files.add_python_resource(".", exe)
+
+    return files
+
+
+# Tell PyOxidizer about the build targets defined above.
+register_target("exe", make_exe)
+register_target("resources", make_embedded_resources, depends=["exe"], default_build_script=True)
+register_target("install", make_install, depends=["exe"], default=True)
+
+# Resolve whatever targets the invoker of this configuration file is requesting
+# be resolved.
+resolve_targets()

--- a/pyoxidizer.bzl
+++ b/pyoxidizer.bzl
@@ -64,9 +64,7 @@ def make_exe():
 
     # Invoke `pip install` using a requirements file and add the collected resources
     # to our binary.
-    exe.add_python_resources(exe.pip_install(["."], optimize=True))
     exe.add_python_resources(exe.pip_install(["-r", "requirements.txt"]))
-
 
     # Read Python files from a local directory and add them to our embedded
     # context, taking just the resources belonging to the `foo` and `bar`
@@ -74,6 +72,12 @@ def make_exe():
     exe.add_python_resources(exe.read_package_root(
         path=".",
         packages=["devservices"],
+    ))
+
+    # Add the generated metadata
+    exe.add_python_resources(exe.read_package_root(
+        path=".",
+        packages=["devservices.egg-info"],  # or the appropriate metadata directory name
     ))
 
     # Return our `PythonExecutable` instance so it can be built and

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=45", "wheel"]
+requires = ["setuptools>=70", "wheel"]
 build-backend = "setuptools.build_meta"
 
 [project]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,5 @@ mypy==1.11.2
 pre-commit==3.6.0
 pytest==8.1.1
 types-PyYAML==6.0.11
+setuptools==70.0.0
+pyoxidizer==0.24.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,5 @@ pre-commit==3.6.0
 pytest==8.1.1
 types-PyYAML==6.0.11
 setuptools==70.0.0
+build==0.8.0
+wheel==0.44.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -6,4 +6,4 @@ pytest==8.1.1
 types-PyYAML==6.0.11
 setuptools==70.0.0
 build==0.8.0
-wheel==0.44.0
+wheel==0.42.0

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,4 +5,3 @@ pre-commit==3.6.0
 pytest==8.1.1
 types-PyYAML==6.0.11
 setuptools==70.0.0
-pyoxidizer==0.24.0


### PR DESCRIPTION
This PR helps us publish a binary for devservices, aiding in a system wide installation of the cli tool. We're using PyOxidizer, which packages the python interpreter into the binary. 

1. builds a binary using PyOxidizer for linux and macos
2. uploads artifacts for the craft release job