### PR TITLE
ref(service-config): Updating service config to include remote deps

### DIFF
--- a/devservices/configs/service_config.py
+++ b/devservices/configs/service_config.py
@@ -15,9 +15,16 @@ VALID_VERSIONS = [0.1]
 
 
 @dataclass
+class RemoteConfig:
+    repo_name: str
+    branch: str
+    repo_link: str
+
+
+@dataclass
 class Dependency:
     description: str
-    link: str | None = None
+    remote: RemoteConfig | None = None
 
 
 @dataclass

--- a/tests/configs/test_service_config.py
+++ b/tests/configs/test_service_config.py
@@ -25,7 +25,11 @@ from tests.testutils import create_config_file
             {
                 "example-dependency-1": {
                     "description": "Example dependency 1",
-                    "link": "https://example.com",
+                    "remote": {
+                        "repo_name": "example-dependency-1",
+                        "branch": "main",
+                        "repo_link": "https://example.com",
+                    },
                 },
                 "example-dependency-2": {
                     "description": "Example dependency 2",
@@ -38,7 +42,11 @@ from tests.testutils import create_config_file
             {
                 "example-dependency-1": {
                     "description": "Example dependency 1",
-                    "link": "https://example.com",
+                    "remote": {
+                        "repo_name": "example-dependency-1",
+                        "branch": "main",
+                        "repo_link": "https://example.com",
+                    },
                 },
                 "example-dependency-2": {
                     "description": "Example dependency 2",
@@ -69,7 +77,10 @@ def test_load_service_config_from_file(
         "version": 0.1,
         "service_name": service_name,
         "dependencies": {
-            key: {"description": value["description"], "link": value.get("link")}
+            key: {
+                "description": value["description"],
+                "remote": value.get("remote"),
+            }
             for key, value in dependencies.items()
         },
         "modes": modes,


### PR DESCRIPTION
In preparation for the dependency management, I am adding some more fields to better track remote dependencies. Additionally, keeping them in a separate dataclass enables us to ensure they are mutually inclusive.