### PR TITLE
ref(dep): Addressing dependency edge cases

### DIFF
--- a/devservices/exceptions.py
+++ b/devservices/exceptions.py
@@ -1,5 +1,7 @@
 from __future__ import annotations
 
+from devservices.configs.service_config import RemoteConfig
+
 
 class ServiceNotFoundError(Exception):
     """Raised when a service is not found."""
@@ -44,4 +46,5 @@ class DockerComposeError(Exception):
 class DependencyError(Exception):
     """Base class for dependency-related errors."""
 
-    pass
+    def __init__(self, remote_config: RemoteConfig):
+        self.remote_config = remote_config

--- a/devservices/exceptions.py
+++ b/devservices/exceptions.py
@@ -39,3 +39,9 @@ class DockerComposeError(Exception):
         self.returncode = returncode
         self.stdout = stdout
         self.stderr = stderr
+
+
+class DependencyError(Exception):
+    """Base class for dependency-related errors."""
+
+    pass

--- a/devservices/exceptions.py
+++ b/devservices/exceptions.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from devservices.configs.service_config import RemoteConfig
-
 
 class ServiceNotFoundError(Exception):
     """Raised when a service is not found."""
@@ -46,5 +44,7 @@ class DockerComposeError(Exception):
 class DependencyError(Exception):
     """Base class for dependency-related errors."""
 
-    def __init__(self, remote_config: RemoteConfig):
-        self.remote_config = remote_config
+    def __init__(self, repo_name: str, repo_link: str, branch: str):
+        self.repo_name = repo_name
+        self.repo_link = repo_link
+        self.branch = branch

--- a/devservices/utils/dependencies.py
+++ b/devservices/utils/dependencies.py
@@ -62,7 +62,9 @@ def _update_dependency(
         )
     except subprocess.CalledProcessError:
         raise DependencyError(
-            remote_config=dependency,
+            repo_name=dependency.repo_name,
+            repo_link=dependency.repo_link,
+            branch=dependency.branch,
         )
 
     # Check if the local repo is up-to-date

--- a/devservices/utils/dependencies.py
+++ b/devservices/utils/dependencies.py
@@ -61,7 +61,9 @@ def _update_dependency(
             cwd=dependency_repo_dir,
         )
     except subprocess.CalledProcessError:
-        raise DependencyError
+        raise DependencyError(
+            remote_config=dependency,
+        )
 
     # Check if the local repo is up-to-date
     local_commit = subprocess.check_output(

--- a/tests/utils/test_dependencies.py
+++ b/tests/utils/test_dependencies.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import shutil
 from pathlib import Path
 from subprocess import SubprocessError
 from unittest import mock
@@ -9,6 +10,7 @@ import pytest
 from devservices.configs.service_config import RemoteConfig
 from devservices.constants import CONFIG_FILE_NAME
 from devservices.constants import DEVSERVICES_DIR_NAME
+from devservices.exceptions import DependencyError
 from devservices.utils.dependencies import install_dependency
 from testing.utils import create_mock_git_repo
 from testing.utils import run_git_command
@@ -182,3 +184,167 @@ def test_install_dependency_basic_with_new_tracked_file(tmp_path: Path) -> None:
             / DEVSERVICES_DIR_NAME
             / "new-file.txt"
         ).exists()
+
+
+def test_install_dependency_basic_with_existing_dir(tmp_path: Path) -> None:
+    with mock.patch(
+        "devservices.utils.dependencies.DEVSERVICES_LOCAL_DEPENDENCIES_DIR",
+        str(tmp_path / "dependency-dir"),
+    ):
+        create_mock_git_repo("basic_repo", tmp_path / "test-repo")
+        mock_dependency = RemoteConfig(
+            repo_name="test-repo",
+            branch="main",
+            repo_link=f"file://{tmp_path / 'test-repo'}",
+        )
+
+        # Create the dependency directory and populate it
+        dependency_dir = tmp_path / "dependency-dir" / "test-repo"
+        dependency_dir.mkdir(parents=True, exist_ok=True)
+        (dependency_dir / "existing-file.txt").touch()
+
+        install_dependency(mock_dependency)
+
+        # Make sure that files outside of the devservices directory are not copied
+        assert not (tmp_path / "dependency-dir" / "test-repo" / "README.md").exists()
+
+        assert (
+            tmp_path
+            / "dependency-dir"
+            / "test-repo"
+            / DEVSERVICES_DIR_NAME
+            / CONFIG_FILE_NAME
+        ).exists()
+
+
+def test_install_dependency_basic_with_existing_invalid_repo(tmp_path: Path) -> None:
+    with mock.patch(
+        "devservices.utils.dependencies.DEVSERVICES_LOCAL_DEPENDENCIES_DIR",
+        str(tmp_path / "dependency-dir"),
+    ):
+        create_mock_git_repo("basic_repo", tmp_path / "test-repo")
+        mock_dependency = RemoteConfig(
+            repo_name="test-repo",
+            branch="main",
+            repo_link=f"file://{tmp_path / 'test-repo'}",
+        )
+
+        # Create the dependency directory and populate it
+        dependency_dir = tmp_path / "dependency-dir" / "test-repo"
+        dependency_dir.mkdir(parents=True, exist_ok=True)
+        dependency_git_dir = dependency_dir / ".git"
+        dependency_git_dir.mkdir(parents=True, exist_ok=True)
+        (dependency_dir / "existing-file.txt").touch()
+
+        install_dependency(mock_dependency)
+
+        # Make sure that files outside of the devservices directory are not copied
+        assert not (tmp_path / "dependency-dir" / "test-repo" / "README.md").exists()
+
+        assert (
+            tmp_path
+            / "dependency-dir"
+            / "test-repo"
+            / DEVSERVICES_DIR_NAME
+            / CONFIG_FILE_NAME
+        ).exists()
+
+
+def test_install_dependency_basic_with_existing_repo_conflicts(tmp_path: Path) -> None:
+    with mock.patch(
+        "devservices.utils.dependencies.DEVSERVICES_LOCAL_DEPENDENCIES_DIR",
+        str(tmp_path / "dependency-dir"),
+    ):
+        mock_git_repo = create_mock_git_repo("basic_repo", tmp_path / "test-repo")
+        mock_dependency = RemoteConfig(
+            repo_name="test-repo",
+            branch="main",
+            repo_link=f"file://{tmp_path / 'test-repo'}",
+        )
+
+        install_dependency(mock_dependency)
+
+        # Make sure that files outside of the devservices directory are not copied
+        assert not (tmp_path / "dependency-dir" / "test-repo" / "README.md").exists()
+
+        assert (
+            tmp_path
+            / "dependency-dir"
+            / "test-repo"
+            / DEVSERVICES_DIR_NAME
+            / CONFIG_FILE_NAME
+        ).exists()
+
+        # Append a new line to the config file in the mock repo and commit the change
+        with open(
+            mock_git_repo / DEVSERVICES_DIR_NAME / CONFIG_FILE_NAME, mode="a"
+        ) as f:
+            f.write("\nEdited config file")
+
+        run_git_command(["add", "."], cwd=mock_git_repo)
+        run_git_command(["commit", "-m", "Edit config file"], cwd=mock_git_repo)
+
+        # Edit the working copy and leave changes unstaged
+        with open(
+            tmp_path
+            / "dependency-dir"
+            / "test-repo"
+            / DEVSERVICES_DIR_NAME
+            / CONFIG_FILE_NAME,
+            mode="a",
+        ) as f:
+            f.write("\nConflict")
+
+        install_dependency(mock_dependency)
+
+        # Check that the config file in the dependency directory has the new line appended
+        with open(
+            tmp_path
+            / "dependency-dir"
+            / "test-repo"
+            / DEVSERVICES_DIR_NAME
+            / CONFIG_FILE_NAME,
+            mode="r",
+        ) as f:
+            assert f.read().endswith("\nEdited config file")
+
+
+def test_install_dependency_basic_with_corrupted_repo(tmp_path: Path) -> None:
+    with mock.patch(
+        "devservices.utils.dependencies.DEVSERVICES_LOCAL_DEPENDENCIES_DIR",
+        str(tmp_path / "dependency-dir"),
+    ):
+        mock_git_repo = create_mock_git_repo("basic_repo", tmp_path / "test-repo")
+        mock_dependency = RemoteConfig(
+            repo_name="test-repo",
+            branch="main",
+            repo_link=f"file://{tmp_path / 'test-repo'}",
+        )
+
+        # Sanity check that the config file is not in the dependency directory (yet)
+        assert not (
+            tmp_path
+            / "dependency-dir"
+            / "test-repo"
+            / DEVSERVICES_DIR_NAME
+            / CONFIG_FILE_NAME
+        ).exists()
+
+        install_dependency(mock_dependency)
+
+        # Sanity check that the new file is not in the dependency directory (yet)
+        assert not (tmp_path / "dependency-dir" / "test-repo" / "new-file.txt").exists()
+
+        assert (
+            tmp_path
+            / "dependency-dir"
+            / "test-repo"
+            / DEVSERVICES_DIR_NAME
+            / CONFIG_FILE_NAME
+        ).exists()
+
+        # Corrupt the git repository by deleting the .git directory
+        shutil.rmtree(mock_git_repo / ".git")
+
+        with pytest.raises(DependencyError):
+            install_dependency(mock_dependency)


### PR DESCRIPTION
Added logic to handle more edge cases and corresponding tests.
* Rather than just checking if the working copy exists, check if it is a valid repo
* When updating a dependency, do so forcibly
* When checking out a dependency, clear any existing files that may exist (this probably will never happen, but it's worth being extra safe)