### PR TITLE
chore(start): Specify project name when starting services

### DIFF
--- a/devservices/commands/logs.py
+++ b/devservices/commands/logs.py
@@ -41,7 +41,7 @@ def logs(args: Namespace) -> None:
     )
     try:
         logs = run_docker_compose_command(
-            f"-f {service_config_file_path} logs {mode_dependencies}"
+            f"-p {service.name} -f {service_config_file_path} logs {mode_dependencies}"
         )
     except DockerComposeError as dce:
         print(f"Failed to get logs for {service.name}: {dce.stderr}")

--- a/devservices/commands/start.py
+++ b/devservices/commands/start.py
@@ -39,7 +39,7 @@ def start(args: Namespace) -> None:
     with Status(f"Starting {service.name}", f"{service.name} started") as status:
         try:
             run_docker_compose_command(
-                f"-f {service_config_file_path} up -d {mode_dependencies}"
+                f"-p {service.name} -f {service_config_file_path} up -d {mode_dependencies}"
             )
         except DockerComposeError as dce:
             status.print(f"Failed to start {service.name}: {dce.stderr}")

--- a/devservices/commands/status.py
+++ b/devservices/commands/status.py
@@ -76,7 +76,7 @@ def status(args: Namespace) -> None:
     )
     try:
         status_json = run_docker_compose_command(
-            f"-f {service_config_file_path} ps {mode_dependencies} --format json"
+            f"-p {service.name} -f {service_config_file_path} ps {mode_dependencies} --format json"
         ).stdout
     except DockerComposeError as dce:
         print(f"Failed to get status for {service.name}: {dce.stderr}")

--- a/devservices/commands/stop.py
+++ b/devservices/commands/stop.py
@@ -39,7 +39,7 @@ def stop(args: Namespace) -> None:
     with Status(f"Stopping {service.name}", f"{service.name} stopped") as status:
         try:
             run_docker_compose_command(
-                f"-f {service_config_file_path} down {mode_dependencies}"
+                f"-p {service.name} -f {service_config_file_path} down {mode_dependencies}"
             )
         except DockerComposeError as dce:
             status.print(f"Failed to stop {service.name}: {dce.stderr}")

--- a/tests/commands/test_start.py
+++ b/tests/commands/test_start.py
@@ -43,6 +43,8 @@ def test_start_simple(mock_run: mock.Mock, tmp_path: Path) -> None:
         [
             "docker",
             "compose",
+            "-p",
+            "example-service",
             "-f",
             f"{tmp_path}/{DEVSERVICES_DIR_NAME}/{CONFIG_FILE_NAME}",
             "up",

--- a/tests/commands/test_stop.py
+++ b/tests/commands/test_stop.py
@@ -44,6 +44,8 @@ def test_stop_simple(mock_run: mock.Mock, tmp_path: Path) -> None:
         [
             "docker",
             "compose",
+            "-p",
+            "example-service",
             "-f",
             f"{tmp_path}/{DEVSERVICES_DIR_NAME}/{CONFIG_FILE_NAME}",
             "down",


### PR DESCRIPTION
This makes it much easier for us to determine how many docker compose configs are currently in use

`docker compose ls` after starting relay and snuba

closes https://github.com/getsentry/devservices/issues/45

Before:
```
NAME                STATUS              CONFIG FILES
devservices         running(3)          /Users/hubertdeng/code/relay/devservices/config.yml,/Users/hubertdeng/code/snuba/devservices/config.yml
```

After:
```
NAME                STATUS              CONFIG FILES
relay               running(2)          /Users/hubertdeng/code/relay/devservices/config.yml
snuba               running(3)          /Users/hubertdeng/code/snuba/devservices/config.yml
```