### PR TITLE
ref(docker-compose): refactoring docker compose util

### DIFF
--- a/devservices/commands/logs.py
+++ b/devservices/commands/logs.py
@@ -1,13 +1,10 @@
 from __future__ import annotations
 
-import os
 import sys
 from argparse import _SubParsersAction
 from argparse import ArgumentParser
 from argparse import Namespace
 
-from devservices.constants import CONFIG_FILE_NAME
-from devservices.constants import DEVSERVICES_DIR_NAME
 from devservices.exceptions import DockerComposeError
 from devservices.utils.docker_compose import run_docker_compose_command
 from devservices.utils.services import find_matching_service
@@ -36,13 +33,8 @@ def logs(args: Namespace) -> None:
     # TODO: allow custom modes to be used
     mode_to_use = "default"
     mode_dependencies = " ".join(modes[mode_to_use])
-    service_config_file_path = os.path.join(
-        service.repo_path, DEVSERVICES_DIR_NAME, CONFIG_FILE_NAME
-    )
     try:
-        logs = run_docker_compose_command(
-            f"-p {service.name} -f {service_config_file_path} logs {mode_dependencies}"
-        )
+        logs = run_docker_compose_command(service, f"logs {mode_dependencies}")
     except DockerComposeError as dce:
         print(f"Failed to get logs for {service.name}: {dce.stderr}")
         exit(1)

--- a/devservices/commands/start.py
+++ b/devservices/commands/start.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-import os
 from argparse import _SubParsersAction
 from argparse import ArgumentParser
 from argparse import Namespace
 
-from devservices.constants import CONFIG_FILE_NAME
-from devservices.constants import DEVSERVICES_DIR_NAME
 from devservices.exceptions import DockerComposeError
 from devservices.utils.console import Status
 from devservices.utils.docker_compose import run_docker_compose_command
@@ -33,14 +30,9 @@ def start(args: Namespace) -> None:
     # TODO: allow custom modes to be used
     mode_to_start = "default"
     mode_dependencies = " ".join(modes[mode_to_start])
-    service_config_file_path = os.path.join(
-        service.repo_path, DEVSERVICES_DIR_NAME, CONFIG_FILE_NAME
-    )
     with Status(f"Starting {service.name}", f"{service.name} started") as status:
         try:
-            run_docker_compose_command(
-                f"-p {service.name} -f {service_config_file_path} up -d {mode_dependencies}"
-            )
+            run_docker_compose_command(service, f"up -d {mode_dependencies}")
         except DockerComposeError as dce:
             status.print(f"Failed to start {service.name}: {dce.stderr}")
             exit(1)

--- a/devservices/commands/status.py
+++ b/devservices/commands/status.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
 import json
-import os
 import sys
 from argparse import _SubParsersAction
 from argparse import ArgumentParser
 from argparse import Namespace
 
-from devservices.constants import CONFIG_FILE_NAME
-from devservices.constants import DEVSERVICES_DIR_NAME
 from devservices.exceptions import DockerComposeError
 from devservices.utils.docker_compose import run_docker_compose_command
 from devservices.utils.services import find_matching_service
@@ -71,12 +68,9 @@ def status(args: Namespace) -> None:
     # TODO: allow custom modes to be used
     mode_to_view = "default"
     mode_dependencies = " ".join(modes[mode_to_view])
-    service_config_file_path = os.path.join(
-        service.repo_path, DEVSERVICES_DIR_NAME, CONFIG_FILE_NAME
-    )
     try:
         status_json = run_docker_compose_command(
-            f"-p {service.name} -f {service_config_file_path} ps {mode_dependencies} --format json"
+            service, f"ps {mode_dependencies} --format json"
         ).stdout
     except DockerComposeError as dce:
         print(f"Failed to get status for {service.name}: {dce.stderr}")

--- a/devservices/commands/stop.py
+++ b/devservices/commands/stop.py
@@ -1,12 +1,9 @@
 from __future__ import annotations
 
-import os
 from argparse import _SubParsersAction
 from argparse import ArgumentParser
 from argparse import Namespace
 
-from devservices.constants import CONFIG_FILE_NAME
-from devservices.constants import DEVSERVICES_DIR_NAME
 from devservices.exceptions import DockerComposeError
 from devservices.utils.console import Status
 from devservices.utils.docker_compose import run_docker_compose_command
@@ -33,14 +30,9 @@ def stop(args: Namespace) -> None:
     # TODO: allow custom modes to be used
     mode_to_stop = "default"
     mode_dependencies = " ".join(modes[mode_to_stop])
-    service_config_file_path = os.path.join(
-        service.repo_path, DEVSERVICES_DIR_NAME, CONFIG_FILE_NAME
-    )
     with Status(f"Stopping {service.name}", f"{service.name} stopped") as status:
         try:
-            run_docker_compose_command(
-                f"-p {service.name} -f {service_config_file_path} down {mode_dependencies}"
-            )
+            run_docker_compose_command(service, f"down {mode_dependencies}")
         except DockerComposeError as dce:
             status.print(f"Failed to stop {service.name}: {dce.stderr}")
             exit(1)

--- a/devservices/utils/docker_compose.py
+++ b/devservices/utils/docker_compose.py
@@ -1,12 +1,28 @@
 from __future__ import annotations
 
+import os
 import subprocess
 
+from devservices.constants import CONFIG_FILE_NAME
+from devservices.constants import DEVSERVICES_DIR_NAME
 from devservices.exceptions import DockerComposeError
+from devservices.utils.services import Service
 
 
-def run_docker_compose_command(command: str) -> subprocess.CompletedProcess[str]:
-    cmd = ["docker", "compose"] + command.split()
+def run_docker_compose_command(
+    service: Service, command: str
+) -> subprocess.CompletedProcess[str]:
+    service_config_file_path = os.path.join(
+        service.repo_path, DEVSERVICES_DIR_NAME, CONFIG_FILE_NAME
+    )
+    cmd = [
+        "docker",
+        "compose",
+        "-p",
+        service.name,
+        "-f",
+        service_config_file_path,
+    ] + command.split()
     try:
         return subprocess.run(cmd, check=True, capture_output=True, text=True)
     except subprocess.CalledProcessError as e:


### PR DESCRIPTION
Found a way to abstract away a bunch of duplicate code by letting the `run_docker_compose_command` utility to automatically add `-p` and `-f` using the service info.