### PR TITLE
ref(dependencies): Providing information about installed remote dependencies after installing

### DIFF
--- a/devservices/utils/dependencies.py
+++ b/devservices/utils/dependencies.py
@@ -143,7 +143,21 @@ def get_installed_remote_dependencies(
             DEPENDENCY_CONFIG_VERSION,
             remote_config.repo_name,
         )
-        service_config = load_service_config_from_file(dependency_repo_dir)
+        if not verify_local_dependency(remote_config):
+            # TODO: what should we do if the local dependency isn't installed correctly?
+            raise DependencyNotInstalledError(
+                repo_name=remote_config.repo_name,
+                repo_link=remote_config.repo_link,
+                branch=remote_config.branch,
+            )
+        try:
+            service_config = load_service_config_from_file(dependency_repo_dir)
+        except (ConfigNotFoundError, ConfigParseError, ConfigValidationError) as e:
+            raise InvalidDependencyConfigError(
+                repo_name=remote_config.repo_name,
+                repo_link=remote_config.repo_link,
+                branch=remote_config.branch,
+            ) from e
         installed_dependencies.add(
             InstalledRemoteDependency(
                 service_name=service_config.service_name, repo_path=dependency_repo_dir

--- a/devservices/utils/docker_compose.py
+++ b/devservices/utils/docker_compose.py
@@ -19,6 +19,7 @@ from devservices.constants import MINIMUM_DOCKER_COMPOSE_VERSION
 from devservices.exceptions import BinaryInstallError
 from devservices.exceptions import DockerComposeError
 from devservices.exceptions import DockerComposeInstallationError
+from devservices.utils.dependencies import get_remote_service_names
 from devservices.utils.dependencies import install_dependencies
 from devservices.utils.dependencies import verify_local_dependencies
 from devservices.utils.install_binary import install_binary
@@ -151,13 +152,16 @@ def run_docker_compose_command(
 ) -> subprocess.CompletedProcess[str]:
     dependencies = list(service.config.dependencies.values())
     if force_update_dependencies:
-        install_dependencies(dependencies)
+        remote_service_names = install_dependencies(dependencies)
     else:
         are_dependencies_valid = verify_local_dependencies(dependencies)
         if not are_dependencies_valid:
             # TODO: Figure out how to handle this case as installing dependencies may not be the right thing to do
             #       since the dependencies may have changed since the service was started.
-            install_dependencies(dependencies)
+            remote_service_names = install_dependencies(dependencies)
+        else:
+            remote_service_names = get_remote_service_names(dependencies)
+    print(remote_service_names)
     relative_local_dependency_directory = os.path.relpath(
         os.path.join(DEVSERVICES_DEPENDENCIES_CACHE_DIR, DEPENDENCY_CONFIG_VERSION),
         service.repo_path,

--- a/devservices/utils/docker_compose.py
+++ b/devservices/utils/docker_compose.py
@@ -19,7 +19,7 @@ from devservices.constants import MINIMUM_DOCKER_COMPOSE_VERSION
 from devservices.exceptions import BinaryInstallError
 from devservices.exceptions import DockerComposeError
 from devservices.exceptions import DockerComposeInstallationError
-from devservices.utils.dependencies import get_remote_service_names
+from devservices.utils.dependencies import get_installed_remote_dependencies
 from devservices.utils.dependencies import install_dependencies
 from devservices.utils.dependencies import verify_local_dependencies
 from devservices.utils.install_binary import install_binary
@@ -152,16 +152,17 @@ def run_docker_compose_command(
 ) -> subprocess.CompletedProcess[str]:
     dependencies = list(service.config.dependencies.values())
     if force_update_dependencies:
-        remote_service_names = install_dependencies(dependencies)
+        remote_dependencies = install_dependencies(dependencies)
     else:
         are_dependencies_valid = verify_local_dependencies(dependencies)
         if not are_dependencies_valid:
             # TODO: Figure out how to handle this case as installing dependencies may not be the right thing to do
             #       since the dependencies may have changed since the service was started.
-            remote_service_names = install_dependencies(dependencies)
+            remote_dependencies = install_dependencies(dependencies)
         else:
-            remote_service_names = get_remote_service_names(dependencies)
-    print(remote_service_names)
+            remote_dependencies = get_installed_remote_dependencies(dependencies)
+    # TODO: remove
+    print(remote_dependencies)
     relative_local_dependency_directory = os.path.relpath(
         os.path.join(DEVSERVICES_DEPENDENCIES_CACHE_DIR, DEPENDENCY_CONFIG_VERSION),
         service.repo_path,

--- a/devservices/utils/docker_compose.py
+++ b/devservices/utils/docker_compose.py
@@ -152,17 +152,15 @@ def run_docker_compose_command(
 ) -> subprocess.CompletedProcess[str]:
     dependencies = list(service.config.dependencies.values())
     if force_update_dependencies:
-        remote_dependencies = install_dependencies(dependencies)
+        install_dependencies(dependencies)
     else:
         are_dependencies_valid = verify_local_dependencies(dependencies)
         if not are_dependencies_valid:
             # TODO: Figure out how to handle this case as installing dependencies may not be the right thing to do
             #       since the dependencies may have changed since the service was started.
-            remote_dependencies = install_dependencies(dependencies)
+            install_dependencies(dependencies)
         else:
-            remote_dependencies = get_installed_remote_dependencies(dependencies)
-    # TODO: remove
-    print(remote_dependencies)
+            get_installed_remote_dependencies(dependencies)
     relative_local_dependency_directory = os.path.relpath(
         os.path.join(DEVSERVICES_DEPENDENCIES_CACHE_DIR, DEPENDENCY_CONFIG_VERSION),
         service.repo_path,

--- a/tests/utils/test_dependencies.py
+++ b/tests/utils/test_dependencies.py
@@ -178,7 +178,63 @@ def test_get_installed_remote_dependencies_empty(tmp_path: Path) -> None:
         assert installed_remote_dependencies == set()
 
 
+def test_get_installed_remote_dependencies_single_dep_not_installed(
+    tmp_path: Path,
+) -> None:
+    with mock.patch(
+        "devservices.utils.dependencies.DEVSERVICES_DEPENDENCIES_CACHE_DIR",
+        str(tmp_path / "dependency-dir"),
+    ):
+        create_mock_git_repo("basic_repo", tmp_path / "test-repo")
+        mock_dependency = Dependency(
+            description="test repo",
+            remote=RemoteConfig(
+                repo_name="test-repo",
+                branch="main",
+                repo_link=f"file://{tmp_path / 'test-repo'}",
+            ),
+        )
+        with pytest.raises(InvalidDependencyConfigError):
+            get_installed_remote_dependencies(dependencies=[mock_dependency])
+
+
 def test_get_installed_remote_dependencies_single_dep_installed(tmp_path: Path) -> None:
+    with mock.patch(
+        "devservices.utils.dependencies.DEVSERVICES_DEPENDENCIES_CACHE_DIR",
+        str(tmp_path / "dependency-dir"),
+    ):
+        create_mock_git_repo("basic_repo", tmp_path / "test-repo")
+        mock_dependency = Dependency(
+            description="test repo",
+            remote=RemoteConfig(
+                repo_name="test-repo",
+                branch="main",
+                repo_link=f"file://{tmp_path / 'test-repo'}",
+            ),
+        )
+        installed_remote_dependencies_initial = install_dependencies([mock_dependency])
+        installed_remote_dependencies = get_installed_remote_dependencies(
+            dependencies=[mock_dependency]
+        )
+        assert installed_remote_dependencies == installed_remote_dependencies_initial
+        assert installed_remote_dependencies == set(
+            [
+                InstalledRemoteDependency(
+                    service_name="basic",
+                    repo_path=str(
+                        tmp_path
+                        / "dependency-dir"
+                        / DEPENDENCY_CONFIG_VERSION
+                        / "test-repo"
+                    ),
+                )
+            ]
+        )
+
+
+def test_get_installed_remote_dependencies_multiple_dep_installed(
+    tmp_path: Path,
+) -> None:
     with mock.patch(
         "devservices.utils.dependencies.DEVSERVICES_DEPENDENCIES_CACHE_DIR",
         str(tmp_path / "dependency-dir"),

--- a/tests/utils/test_dependencies.py
+++ b/tests/utils/test_dependencies.py
@@ -19,6 +19,7 @@ from devservices.exceptions import InvalidDependencyConfigError
 from devservices.utils.dependencies import GitConfigManager
 from devservices.utils.dependencies import install_dependencies
 from devservices.utils.dependencies import install_dependency
+from devservices.utils.dependencies import InstalledRemoteDependency
 from devservices.utils.dependencies import verify_local_dependencies
 from testing.utils import create_config_file
 from testing.utils import create_mock_git_repo
@@ -782,7 +783,30 @@ def test_install_dependency_nested_dependency(tmp_path: Path) -> None:
             / CONFIG_FILE_NAME
         ).exists()
 
-        install_dependency(main_repo_dependency)
+        installed_remote_dependencies = install_dependency(main_repo_dependency)
+
+        assert installed_remote_dependencies == set(
+            [
+                InstalledRemoteDependency(
+                    service_name="basic",
+                    repo_path=str(
+                        tmp_path
+                        / "dependency-dir"
+                        / DEPENDENCY_CONFIG_VERSION
+                        / "nested-repo"
+                    ),
+                ),
+                InstalledRemoteDependency(
+                    service_name="complex",
+                    repo_path=str(
+                        tmp_path
+                        / "dependency-dir"
+                        / DEPENDENCY_CONFIG_VERSION
+                        / "main-repo"
+                    ),
+                ),
+            ]
+        )
 
         assert (
             tmp_path
@@ -892,7 +916,30 @@ def test_install_dependency_nested_dependency_with_edits(tmp_path: Path) -> None
             / CONFIG_FILE_NAME
         ).exists()
 
-        install_dependency(main_repo_dependency)
+        installed_remote_dependencies = install_dependency(main_repo_dependency)
+
+        assert installed_remote_dependencies == set(
+            [
+                InstalledRemoteDependency(
+                    service_name="basic",
+                    repo_path=str(
+                        tmp_path
+                        / "dependency-dir"
+                        / DEPENDENCY_CONFIG_VERSION
+                        / "nested-repo"
+                    ),
+                ),
+                InstalledRemoteDependency(
+                    service_name="complex",
+                    repo_path=str(
+                        tmp_path
+                        / "dependency-dir"
+                        / DEPENDENCY_CONFIG_VERSION
+                        / "main-repo"
+                    ),
+                ),
+            ]
+        )
 
         assert (
             tmp_path
@@ -1065,7 +1112,39 @@ def test_install_dependencies_nested_dependency_file_contention(tmp_path: Path) 
         )
         dependencies = [repo_a_dependency, repo_b_dependency]
 
-        install_dependencies(dependencies)
+        installed_remote_dependencies = install_dependencies(dependencies)
+
+        assert installed_remote_dependencies == set(
+            [
+                InstalledRemoteDependency(
+                    service_name="repo-a",
+                    repo_path=str(
+                        tmp_path
+                        / "dependency-dir"
+                        / DEPENDENCY_CONFIG_VERSION
+                        / "repo-a"
+                    ),
+                ),
+                InstalledRemoteDependency(
+                    service_name="repo-b",
+                    repo_path=str(
+                        tmp_path
+                        / "dependency-dir"
+                        / DEPENDENCY_CONFIG_VERSION
+                        / "repo-b"
+                    ),
+                ),
+                InstalledRemoteDependency(
+                    service_name="basic",
+                    repo_path=str(
+                        tmp_path
+                        / "dependency-dir"
+                        / DEPENDENCY_CONFIG_VERSION
+                        / "repo-c"
+                    ),
+                ),
+            ]
+        )
 
         assert (
             tmp_path

--- a/tests/utils/test_dependencies.py
+++ b/tests/utils/test_dependencies.py
@@ -14,6 +14,7 @@ from devservices.constants import DEPENDENCY_CONFIG_VERSION
 from devservices.constants import DEPENDENCY_GIT_PARTIAL_CLONE_CONFIG_OPTIONS
 from devservices.constants import DEVSERVICES_DIR_NAME
 from devservices.exceptions import DependencyError
+from devservices.exceptions import DependencyNotInstalledError
 from devservices.exceptions import FailedToSetGitConfigError
 from devservices.exceptions import InvalidDependencyConfigError
 from devservices.utils.dependencies import get_installed_remote_dependencies
@@ -194,47 +195,11 @@ def test_get_installed_remote_dependencies_single_dep_not_installed(
                 repo_link=f"file://{tmp_path / 'test-repo'}",
             ),
         )
-        with pytest.raises(InvalidDependencyConfigError):
+        with pytest.raises(DependencyNotInstalledError):
             get_installed_remote_dependencies(dependencies=[mock_dependency])
 
 
 def test_get_installed_remote_dependencies_single_dep_installed(tmp_path: Path) -> None:
-    with mock.patch(
-        "devservices.utils.dependencies.DEVSERVICES_DEPENDENCIES_CACHE_DIR",
-        str(tmp_path / "dependency-dir"),
-    ):
-        create_mock_git_repo("basic_repo", tmp_path / "test-repo")
-        mock_dependency = Dependency(
-            description="test repo",
-            remote=RemoteConfig(
-                repo_name="test-repo",
-                branch="main",
-                repo_link=f"file://{tmp_path / 'test-repo'}",
-            ),
-        )
-        installed_remote_dependencies_initial = install_dependencies([mock_dependency])
-        installed_remote_dependencies = get_installed_remote_dependencies(
-            dependencies=[mock_dependency]
-        )
-        assert installed_remote_dependencies == installed_remote_dependencies_initial
-        assert installed_remote_dependencies == set(
-            [
-                InstalledRemoteDependency(
-                    service_name="basic",
-                    repo_path=str(
-                        tmp_path
-                        / "dependency-dir"
-                        / DEPENDENCY_CONFIG_VERSION
-                        / "test-repo"
-                    ),
-                )
-            ]
-        )
-
-
-def test_get_installed_remote_dependencies_multiple_dep_installed(
-    tmp_path: Path,
-) -> None:
     with mock.patch(
         "devservices.utils.dependencies.DEVSERVICES_DEPENDENCIES_CACHE_DIR",
         str(tmp_path / "dependency-dir"),

--- a/tests/utils/test_dependencies.py
+++ b/tests/utils/test_dependencies.py
@@ -16,6 +16,7 @@ from devservices.constants import DEVSERVICES_DIR_NAME
 from devservices.exceptions import DependencyError
 from devservices.exceptions import FailedToSetGitConfigError
 from devservices.exceptions import InvalidDependencyConfigError
+from devservices.utils.dependencies import get_installed_remote_dependencies
 from devservices.utils.dependencies import GitConfigManager
 from devservices.utils.dependencies import install_dependencies
 from devservices.utils.dependencies import install_dependency
@@ -164,6 +165,51 @@ def test_verify_local_dependencies_with_remote_dependencies(tmp_path: Path) -> N
         install_dependency(remote_config)
 
         assert verify_local_dependencies([dependency])
+
+
+def test_get_installed_remote_dependencies_empty(tmp_path: Path) -> None:
+    with mock.patch(
+        "devservices.utils.dependencies.DEVSERVICES_DEPENDENCIES_CACHE_DIR",
+        str(tmp_path / "dependency-dir"),
+    ):
+        installed_remote_dependencies = get_installed_remote_dependencies(
+            dependencies=[]
+        )
+        assert installed_remote_dependencies == set()
+
+
+def test_get_installed_remote_dependencies_single_dep_installed(tmp_path: Path) -> None:
+    with mock.patch(
+        "devservices.utils.dependencies.DEVSERVICES_DEPENDENCIES_CACHE_DIR",
+        str(tmp_path / "dependency-dir"),
+    ):
+        create_mock_git_repo("basic_repo", tmp_path / "test-repo")
+        mock_dependency = Dependency(
+            description="test repo",
+            remote=RemoteConfig(
+                repo_name="test-repo",
+                branch="main",
+                repo_link=f"file://{tmp_path / 'test-repo'}",
+            ),
+        )
+        installed_remote_dependencies_initial = install_dependencies([mock_dependency])
+        installed_remote_dependencies = get_installed_remote_dependencies(
+            dependencies=[mock_dependency]
+        )
+        assert installed_remote_dependencies == installed_remote_dependencies_initial
+        assert installed_remote_dependencies == set(
+            [
+                InstalledRemoteDependency(
+                    service_name="basic",
+                    repo_path=str(
+                        tmp_path
+                        / "dependency-dir"
+                        / DEPENDENCY_CONFIG_VERSION
+                        / "test-repo"
+                    ),
+                )
+            ]
+        )
 
 
 def test_install_dependency_invalid_repo(tmp_path: Path) -> None:


### PR DESCRIPTION
To enable us to properly manage start and stop (as well as other commands) with nested dependencies, we need to know what nested service dependencies we need to start/stop separately and what dependencies may be shared between services.