### PR TITLE
feat(devservices): Run commands for nested dependencies by project

### DIFF
--- a/devservices/commands/logs.py
+++ b/devservices/commands/logs.py
@@ -33,12 +33,13 @@ def logs(args: Namespace) -> None:
     modes = service.config.modes
     # TODO: allow custom modes to be used
     mode_to_use = "default"
-    mode_dependencies = " ".join(modes[mode_to_use])
+    mode_dependencies = modes[mode_to_use]
 
     try:
-        logs = run_docker_compose_command(service, f"logs {mode_dependencies}")
+        logs = run_docker_compose_command(service, "logs", mode_dependencies)
     except DockerComposeError as dce:
         print(f"Failed to get logs for {service.name}: {dce.stderr}")
         exit(1)
-    sys.stdout.write(logs.stdout)
-    sys.stdout.flush()
+    for log in logs:
+        sys.stdout.write(log.stdout)
+        sys.stdout.flush()

--- a/devservices/commands/start.py
+++ b/devservices/commands/start.py
@@ -30,12 +30,12 @@ def start(args: Namespace) -> None:
     modes = service.config.modes
     # TODO: allow custom modes to be used
     mode_to_start = "default"
-    mode_dependencies = " ".join(modes[mode_to_start])
+    mode_dependencies = modes[mode_to_start]
 
     with Status(f"Starting {service.name}", f"{service.name} started") as status:
         try:
             run_docker_compose_command(
-                service, f"up -d {mode_dependencies}", force_update_dependencies=True
+                service, "up", mode_dependencies, ["-d"], force_update_dependencies=True
             )
         except DockerComposeError as dce:
             status.print(f"Failed to start {service.name}: {dce.stderr}")

--- a/devservices/commands/status.py
+++ b/devservices/commands/status.py
@@ -68,21 +68,22 @@ def status(args: Namespace) -> None:
     modes = service.config.modes
     # TODO: allow custom modes to be used
     mode_to_view = "default"
-    mode_dependencies = " ".join(modes[mode_to_view])
+    mode_dependencies = modes[mode_to_view]
 
     try:
-        status_json = run_docker_compose_command(
-            service, f"ps {mode_dependencies} --format json"
-        ).stdout
+        status_jsons = run_docker_compose_command(
+            service, "ps", mode_dependencies, options=["--format", "json"]
+        )
     except DockerComposeError as dce:
         print(f"Failed to get status for {service.name}: {dce.stderr}")
         exit(1)
     # If the service is not running, the status_json will be empty
-    if not status_json:
+    if len(status_jsons) == 0:
         print(f"{service.name} is not running")
         return
     output = f"Service: {service.name}\n\n"
-    output += format_status_output(status_json)
+    for status_json in status_jsons:
+        output += format_status_output(status_json.stdout)
     output += "=" * LINE_LENGTH
     sys.stdout.write(output + "\n")
     sys.stdout.flush()

--- a/devservices/commands/stop.py
+++ b/devservices/commands/stop.py
@@ -30,11 +30,11 @@ def stop(args: Namespace) -> None:
     modes = service.config.modes
     # TODO: allow custom modes to be used
     mode_to_stop = "default"
-    mode_dependencies = " ".join(modes[mode_to_stop])
+    mode_dependencies = modes[mode_to_stop]
 
     with Status(f"Stopping {service.name}", f"{service.name} stopped") as status:
         try:
-            run_docker_compose_command(service, f"down {mode_dependencies}")
+            run_docker_compose_command(service, "down", mode_dependencies)
         except DockerComposeError as dce:
             status.print(f"Failed to stop {service.name}: {dce.stderr}")
             exit(1)

--- a/devservices/configs/service_config.py
+++ b/devservices/configs/service_config.py
@@ -20,6 +20,7 @@ class RemoteConfig:
     repo_name: str
     branch: str
     repo_link: str
+    mode: str = "default"
 
 
 @dataclass

--- a/devservices/utils/dependencies.py
+++ b/devservices/utils/dependencies.py
@@ -32,6 +32,7 @@ from devservices.utils.file_lock import lock
 class InstalledRemoteDependency:
     service_name: str
     repo_path: str
+    mode: str = "default"
 
 
 class SparseCheckoutManager:
@@ -160,7 +161,9 @@ def get_installed_remote_dependencies(
             ) from e
         installed_dependencies.add(
             InstalledRemoteDependency(
-                service_name=service_config.service_name, repo_path=dependency_repo_dir
+                service_name=service_config.service_name,
+                repo_path=dependency_repo_dir,
+                mode=remote_config.mode,
             )
         )
         nested_remote_configs = _get_remote_configs(
@@ -252,6 +255,7 @@ def install_dependency(dependency: RemoteConfig) -> set[InstalledRemoteDependenc
             InstalledRemoteDependency(
                 service_name=installed_config.service_name,
                 repo_path=dependency_repo_dir,
+                mode=dependency.mode,
             )
         ]
     )

--- a/devservices/utils/docker_compose.py
+++ b/devservices/utils/docker_compose.py
@@ -162,9 +162,9 @@ def _get_non_remote_services(
         "--services",
     ]
     try:
-        config_services = subprocess.run(
-            config_command, capture_output=True, text=True, env=current_env
-        ).stdout
+        config_services = subprocess.check_output(
+            config_command, text=True, env=current_env
+        )
     except subprocess.CalledProcessError as e:
         raise DockerComposeError(
             command=" ".join(config_command),
@@ -172,8 +172,7 @@ def _get_non_remote_services(
             stdout=e.stdout,
             stderr=e.stderr,
         ) from e
-    services_defined_in_config = set(config_services.splitlines())
-    return services_defined_in_config
+    return set(config_services.splitlines())
 
 
 def _get_docker_compose_commands_to_run(

--- a/devservices/utils/docker_compose.py
+++ b/devservices/utils/docker_compose.py
@@ -197,7 +197,7 @@ def __get_all_commands_to_run(
             config_path,
             command,
         ]
-        + list(services_to_use)
+        + sorted(list(services_to_use))
         + options
     )
     for dependency in remote_dependencies:

--- a/testing/resources/child-service-repo/README.md
+++ b/testing/resources/child-service-repo/README.md
@@ -1,0 +1,1 @@
+This is a child service that is used for testing purposes.

--- a/testing/resources/child-service-repo/devservices/config.yml
+++ b/testing/resources/child-service-repo/devservices/config.yml
@@ -1,0 +1,19 @@
+x-sentry-service-config:
+  version: 0.1
+  service_name: child-service
+  dependencies:
+    child-service:
+      description: This is a remote child service that is used for testing purposes.
+  modes:
+    default: [child-service]
+
+services:
+  child-service:
+    image: child-service
+    networks:
+      - sentry
+
+networks:
+  sentry:
+    name: sentry
+    external: true

--- a/testing/resources/grandparent-service-repo/README.md
+++ b/testing/resources/grandparent-service-repo/README.md
@@ -1,0 +1,1 @@
+This is a grandparent service that is used for testing purposes.

--- a/testing/resources/grandparent-service-repo/devservices/config.yml
+++ b/testing/resources/grandparent-service-repo/devservices/config.yml
@@ -1,0 +1,24 @@
+x-sentry-service-config:
+  version: 0.1
+  service_name: grandparent-service
+  dependencies:
+    parent-service:
+      description: This is a remote parent service that is used for testing purposes.
+      remote:
+        repo_name: parent-service
+        branch: main
+        repo_link: https://github.com/example/parent-service.git
+    grandparent-service:
+      description: This is a remote nested dependency service that is used for testing purposes.
+  modes:
+    default: [parent-service, grandparent-service]
+services:
+  grandparent-service:
+    image: grandparent-service
+    networks:
+      - sentry
+
+networks:
+  sentry:
+    name: sentry
+    external: true

--- a/testing/resources/parent-service-repo/README.md
+++ b/testing/resources/parent-service-repo/README.md
@@ -1,0 +1,1 @@
+This is a parent service that is used for testing purposes.

--- a/testing/resources/parent-service-repo/devservices/config.yml
+++ b/testing/resources/parent-service-repo/devservices/config.yml
@@ -1,0 +1,24 @@
+x-sentry-service-config:
+  version: 0.1
+  service_name: parent-service
+  dependencies:
+    child-service:
+      description: This is a remote child service that is used for testing purposes.
+      remote:
+        repo_name: child-service
+        branch: main
+        repo_link: https://github.com/example/child-service.git
+    parent-service:
+      description: This is a remote parent service that is used for testing purposes.
+  modes:
+    default: [parent-service, child-service]
+services:
+  parent-service:
+    image: parent-service
+    networks:
+      - sentry
+
+networks:
+  sentry:
+    name: sentry
+    external: true

--- a/tests/commands/test_start.py
+++ b/tests/commands/test_start.py
@@ -16,7 +16,14 @@ from devservices.constants import DEVSERVICES_DIR_NAME
 from testing.utils import create_config_file
 
 
-@mock.patch("devservices.utils.docker_compose.subprocess.run")
+@mock.patch(
+    "devservices.utils.docker_compose.subprocess.run",
+    return_value=subprocess.CompletedProcess(
+        args=["docker", "compose", "config", "--services"],
+        returncode=0,
+        stdout="clickhouse\nredis\n",
+    ),
+)
 def test_start_simple(mock_run: mock.Mock, tmp_path: Path) -> None:
     with mock.patch(
         "devservices.utils.docker_compose.DEVSERVICES_DEPENDENCIES_CACHE_DIR",
@@ -55,7 +62,7 @@ def test_start_simple(mock_run: mock.Mock, tmp_path: Path) -> None:
             == f"../dependency-dir/{DEPENDENCY_CONFIG_VERSION}"
         )
 
-        mock_run.assert_called_once_with(
+        mock_run.assert_called_with(
             [
                 "docker",
                 "compose",
@@ -64,9 +71,9 @@ def test_start_simple(mock_run: mock.Mock, tmp_path: Path) -> None:
                 "-f",
                 f"{service_path}/{DEVSERVICES_DIR_NAME}/{CONFIG_FILE_NAME}",
                 "up",
-                "-d",
-                "redis",
                 "clickhouse",
+                "redis",
+                "-d",
             ],
             check=True,
             capture_output=True,

--- a/tests/commands/test_stop.py
+++ b/tests/commands/test_stop.py
@@ -16,7 +16,14 @@ from devservices.constants import DEVSERVICES_DIR_NAME
 from testing.utils import create_config_file
 
 
-@mock.patch("devservices.utils.docker_compose.subprocess.run")
+@mock.patch(
+    "devservices.utils.docker_compose.subprocess.run",
+    return_value=subprocess.CompletedProcess(
+        args=["docker", "compose", "config", "--services"],
+        returncode=0,
+        stdout="clickhouse\nredis\n",
+    ),
+)
 def test_stop_simple(mock_run: mock.Mock, tmp_path: Path) -> None:
     with mock.patch(
         "devservices.utils.docker_compose.DEVSERVICES_DEPENDENCIES_CACHE_DIR",
@@ -55,7 +62,7 @@ def test_stop_simple(mock_run: mock.Mock, tmp_path: Path) -> None:
             == f"../dependency-dir/{DEPENDENCY_CONFIG_VERSION}"
         )
 
-        mock_run.assert_called_once_with(
+        mock_run.assert_called_with(
             [
                 "docker",
                 "compose",
@@ -64,8 +71,8 @@ def test_stop_simple(mock_run: mock.Mock, tmp_path: Path) -> None:
                 "-f",
                 f"{service_path}/{DEVSERVICES_DIR_NAME}/{CONFIG_FILE_NAME}",
                 "down",
-                "redis",
                 "clickhouse",
+                "redis",
             ],
             check=True,
             capture_output=True,

--- a/tests/configs/test_service_config.py
+++ b/tests/configs/test_service_config.py
@@ -29,6 +29,7 @@ from testing.utils import create_config_file
                         "repo_name": "example-dependency-1",
                         "branch": "main",
                         "repo_link": "https://example.com",
+                        "mode": "default",
                     },
                 },
                 "example-dependency-2": {
@@ -46,6 +47,7 @@ from testing.utils import create_config_file
                         "repo_name": "example-dependency-1",
                         "branch": "main",
                         "repo_link": "https://example.com",
+                        "mode": "default",
                     },
                 },
                 "example-dependency-2": {


### PR DESCRIPTION
This adds support for running docker commands for nested remote dependencies. Each docker compose command is run  with its own appropriate service name as its project.  

For example:
```
Grandparent (grandparent-service)
--> Parent (parent-service)
----> Child (child-service-1, child-service-2)
```
Docker Compose projects:
Grandparent: 
- grandparent-service

Parent:
- parent-service

Child:
- child-service-1
- child-service-2




