### PR TITLE
fix(logs): Fixing naming issue with logs

### DIFF
--- a/devservices/commands/logs.py
+++ b/devservices/commands/logs.py
@@ -36,10 +36,10 @@ def logs(args: Namespace) -> None:
     mode_dependencies = modes[mode_to_use]
 
     try:
-        logs = run_docker_compose_command(service, "logs", mode_dependencies)
+        logs_output = run_docker_compose_command(service, "logs", mode_dependencies)
     except DockerComposeError as dce:
         print(f"Failed to get logs for {service.name}: {dce.stderr}")
         exit(1)
-    for log in logs:
+    for log in logs_output:
         sys.stdout.write(log.stdout)
         sys.stdout.flush()


### PR DESCRIPTION
Fixing naming in the logs command to avoid overwriting the function definition itself 