### PR TITLE
fix(list-services): Use state for finding status of list services

### DIFF
--- a/devservices/commands/list_services.py
+++ b/devservices/commands/list_services.py
@@ -5,8 +5,8 @@ from argparse import ArgumentParser
 from argparse import Namespace
 
 from devservices.utils.devenv import get_coderoot
-from devservices.utils.docker_compose import get_active_docker_compose_projects
 from devservices.utils.services import get_local_services
+from devservices.utils.state import State
 
 
 def add_parser(subparsers: _SubParsersAction[ArgumentParser]) -> None:
@@ -28,14 +28,14 @@ def list_services(args: Namespace) -> None:
     # Get all of the services installed locally
     coderoot = get_coderoot()
     services = get_local_services(coderoot)
-    running_projects = get_active_docker_compose_projects()
+    running_services = State().get_started_services()
 
     if not services:
         print("No services found")
         return
 
     services_to_show = (
-        services if args.all else [s for s in services if s.name in running_projects]
+        services if args.all else [s for s in services if s.name in running_services]
     )
 
     if args.all:
@@ -44,7 +44,7 @@ def list_services(args: Namespace) -> None:
         print("Running services:")
 
     for service in services_to_show:
-        status = "running" if service.name in running_projects else "stopped"
+        status = "running" if service.name in running_services else "stopped"
         print(f"- {service.name}")
         print(f"  status: {status}")
         print(f"  location: {service.repo_path}")

--- a/devservices/commands/list_services.py
+++ b/devservices/commands/list_services.py
@@ -28,7 +28,8 @@ def list_services(args: Namespace) -> None:
     # Get all of the services installed locally
     coderoot = get_coderoot()
     services = get_local_services(coderoot)
-    running_services = State().get_started_services()
+    state = State()
+    running_services = state.get_started_services()
 
     if not services:
         print("No services found")

--- a/devservices/utils/docker_compose.py
+++ b/devservices/utils/docker_compose.py
@@ -29,21 +29,6 @@ from devservices.utils.install_binary import install_binary
 from devservices.utils.services import Service
 
 
-def get_active_docker_compose_projects() -> list[str]:
-    cmd = ["docker", "compose", "ls", "-q"]
-    try:
-        running_projects = subprocess.check_output(cmd, text=True)
-    except subprocess.CalledProcessError as e:
-        raise DockerComposeError(
-            command=" ".join(cmd),
-            returncode=e.returncode,
-            stdout=e.stdout,
-            stderr=e.stderr,
-        )
-    # docker compose ls always returns newline delimited string with an extra newline at the end
-    return running_projects.split("\n")[:-1]
-
-
 def install_docker_compose() -> None:
     # Determine the platform
     system = platform.system()

--- a/tests/commands/test_list_services.py
+++ b/tests/commands/test_list_services.py
@@ -7,20 +7,19 @@ from unittest import mock
 import pytest
 
 from devservices.commands.list_services import list_services
+from devservices.utils.state import State
 from testing.utils import create_config_file
 
 
-@mock.patch(
-    "devservices.utils.docker_compose.subprocess.run",
-    return_value=Namespace(stdout="\nexample-service\n"),
-)
 def test_list_running_services(
-    mock_run: mock.Mock, tmp_path: Path, capsys: pytest.CaptureFixture[str]
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
 ) -> None:
     with mock.patch(
         "devservices.commands.list_services.get_coderoot",
         return_value=str(tmp_path / "code"),
-    ):
+    ), mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")):
+        state = State()
+        state.add_started_service("example-service", "default")
         config = {
             "x-sentry-service-config": {
                 "version": 0.1,
@@ -52,17 +51,13 @@ def test_list_running_services(
         )
 
 
-@mock.patch(
-    "devservices.utils.docker_compose.subprocess.run",
-    return_value=Namespace(stdout="\nexample-service\n"),
-)
-def test_list_all_services(
-    mock_run: mock.Mock, tmp_path: Path, capsys: pytest.CaptureFixture[str]
-) -> None:
+def test_list_all_services(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
     with mock.patch(
         "devservices.commands.list_services.get_coderoot",
         return_value=str(tmp_path / "code"),
-    ):
+    ), mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")):
+        state = State()
+        state.add_started_service("example-service", "default")
         config = {
             "x-sentry-service-config": {
                 "version": 0.1,


### PR DESCRIPTION
For `list-services`, we are incorrectly marking local services as running when services are brought up with remote dependencies. 

Say for example snuba is brought up that depends on shared-redis and shared-kafka whose definitions are pulled in remotely. `devservices list-services` would show local copies of shared-redis and shared-kafka as running. This fixes that