### PR TITLE
fix(logs): Limit log length and check to ensure service is running before printing logs

### DIFF
--- a/devservices/commands/logs.py
+++ b/devservices/commands/logs.py
@@ -5,6 +5,7 @@ from argparse import _SubParsersAction
 from argparse import ArgumentParser
 from argparse import Namespace
 
+from devservices.constants import MAX_LOG_LINES
 from devservices.exceptions import DependencyError
 from devservices.exceptions import DockerComposeError
 from devservices.utils.docker_compose import run_docker_compose_command
@@ -45,7 +46,7 @@ def logs(args: Namespace) -> None:
 
     try:
         logs_output = run_docker_compose_command(
-            service, "logs", mode_dependencies, options=["-n", "100"]
+            service, "logs", mode_dependencies, options=["-n", MAX_LOG_LINES]
         )
     except DependencyError as de:
         print(str(de))

--- a/devservices/commands/logs.py
+++ b/devservices/commands/logs.py
@@ -41,7 +41,7 @@ def logs(args: Namespace) -> None:
     running_services = state.get_started_services()
     if service_name not in running_services:
         print(f"Service {service_name} is not running")
-        exit(0)
+        return
 
     try:
         logs_output = run_docker_compose_command(

--- a/devservices/commands/logs.py
+++ b/devservices/commands/logs.py
@@ -37,7 +37,8 @@ def logs(args: Namespace) -> None:
     mode_to_use = "default"
     mode_dependencies = modes[mode_to_use]
 
-    running_services = State().get_started_services()
+    state = State()
+    running_services = state.get_started_services()
     if service_name not in running_services:
         print(f"Service {service_name} is not running")
         exit(0)

--- a/devservices/commands/logs.py
+++ b/devservices/commands/logs.py
@@ -9,6 +9,7 @@ from devservices.exceptions import DependencyError
 from devservices.exceptions import DockerComposeError
 from devservices.utils.docker_compose import run_docker_compose_command
 from devservices.utils.services import find_matching_service
+from devservices.utils.state import State
 
 
 def add_parser(subparsers: _SubParsersAction[ArgumentParser]) -> None:
@@ -36,8 +37,15 @@ def logs(args: Namespace) -> None:
     mode_to_use = "default"
     mode_dependencies = modes[mode_to_use]
 
+    running_services = State().get_started_services()
+    if service_name not in running_services:
+        print(f"Service {service_name} is not running")
+        exit(0)
+
     try:
-        logs_output = run_docker_compose_command(service, "logs", mode_dependencies)
+        logs_output = run_docker_compose_command(
+            service, "logs", mode_dependencies, options=["-n", "100"]
+        )
     except DependencyError as de:
         print(str(de))
         exit(1)

--- a/devservices/constants.py
+++ b/devservices/constants.py
@@ -23,3 +23,4 @@ DEPENDENCY_GIT_PARTIAL_CLONE_CONFIG_OPTIONS = {
 DOCKER_COMPOSE_DOWNLOAD_URL = "https://github.com/docker/compose/releases/download"
 DEVSERVICES_DOWNLOAD_URL = "https://github.com/getsentry/devservices/releases/download"
 BINARY_PERMISSIONS = 0o755
+MAX_LOG_LINES = "100"


### PR DESCRIPTION
This limits the amount of logs that are printed to console. It also fixes a bug where logs can be printed despite a service is not running if a dependency of the service is running.