### PR TITLE
ref(docker-compose): Moving dependency logic out of docker compose

### DIFF
--- a/devservices/commands/logs.py
+++ b/devservices/commands/logs.py
@@ -56,8 +56,8 @@ def logs(args: Namespace) -> None:
             service,
             "logs",
             mode_dependencies,
+            remote_dependencies,
             options=["-n", MAX_LOG_LINES],
-            remote_dependencies=remote_dependencies,
         )
     except DockerComposeError as dce:
         console.failure(f"Failed to get logs for {service.name}: {dce.stderr}")

--- a/devservices/commands/logs.py
+++ b/devservices/commands/logs.py
@@ -8,6 +8,7 @@ from devservices.constants import MAX_LOG_LINES
 from devservices.exceptions import DependencyError
 from devservices.exceptions import DockerComposeError
 from devservices.utils.console import Console
+from devservices.utils.dependencies import install_and_verify_dependencies
 from devservices.utils.docker_compose import run_docker_compose_command
 from devservices.utils.services import find_matching_service
 from devservices.utils.state import State
@@ -46,12 +47,18 @@ def logs(args: Namespace) -> None:
         return
 
     try:
-        logs_output = run_docker_compose_command(
-            service, "logs", mode_dependencies, options=["-n", MAX_LOG_LINES]
-        )
+        remote_dependencies = install_and_verify_dependencies(service)
     except DependencyError as de:
         console.failure(str(de))
         exit(1)
+    try:
+        logs_output = run_docker_compose_command(
+            service,
+            "logs",
+            mode_dependencies,
+            options=["-n", MAX_LOG_LINES],
+            remote_dependencies=remote_dependencies,
+        )
     except DockerComposeError as dce:
         console.failure(f"Failed to get logs for {service.name}: {dce.stderr}")
         exit(1)

--- a/devservices/commands/start.py
+++ b/devservices/commands/start.py
@@ -53,8 +53,8 @@ def start(args: Namespace) -> None:
                 service,
                 "up",
                 mode_dependencies,
-                ["-d"],
-                remote_dependencies=remote_dependencies,
+                remote_dependencies,
+                options=["-d"],
             )
         except DockerComposeError as dce:
             status.failure(f"Failed to start {service.name}: {dce.stderr}")

--- a/devservices/commands/status.py
+++ b/devservices/commands/status.py
@@ -85,8 +85,8 @@ def status(args: Namespace) -> None:
             service,
             "ps",
             mode_dependencies,
+            remote_dependencies,
             options=["--format", "json"],
-            remote_dependencies=remote_dependencies,
         )
     except DockerComposeError as dce:
         console.failure(f"Failed to get status for {service.name}: {dce.stderr}")

--- a/devservices/commands/status.py
+++ b/devservices/commands/status.py
@@ -8,6 +8,7 @@ from argparse import Namespace
 from devservices.exceptions import DependencyError
 from devservices.exceptions import DockerComposeError
 from devservices.utils.console import Console
+from devservices.utils.dependencies import install_and_verify_dependencies
 from devservices.utils.docker_compose import run_docker_compose_command
 from devservices.utils.services import find_matching_service
 
@@ -75,12 +76,18 @@ def status(args: Namespace) -> None:
     mode_dependencies = modes[mode_to_view]
 
     try:
-        status_json_results = run_docker_compose_command(
-            service, "ps", mode_dependencies, options=["--format", "json"]
-        )
+        remote_dependencies = install_and_verify_dependencies(service)
     except DependencyError as de:
         console.failure(str(de))
         exit(1)
+    try:
+        status_json_results = run_docker_compose_command(
+            service,
+            "ps",
+            mode_dependencies,
+            options=["--format", "json"],
+            remote_dependencies=remote_dependencies,
+        )
     except DockerComposeError as dce:
         console.failure(f"Failed to get status for {service.name}: {dce.stderr}")
         exit(1)

--- a/devservices/commands/stop.py
+++ b/devservices/commands/stop.py
@@ -60,7 +60,7 @@ def stop(args: Namespace) -> None:
                 service,
                 "down",
                 mode_dependencies,
-                remote_dependencies=remote_dependencies,
+                remote_dependencies,
             )
         except DockerComposeError as dce:
             status.failure(f"Failed to stop {service.name}: {dce.stderr}")

--- a/devservices/commands/stop.py
+++ b/devservices/commands/stop.py
@@ -8,6 +8,8 @@ from devservices.exceptions import DependencyError
 from devservices.exceptions import DockerComposeError
 from devservices.utils.console import Console
 from devservices.utils.console import Status
+from devservices.utils.dependencies import get_non_shared_remote_dependencies
+from devservices.utils.dependencies import install_and_verify_dependencies
 from devservices.utils.docker_compose import run_docker_compose_command
 from devservices.utils.services import find_matching_service
 from devservices.utils.state import State
@@ -46,10 +48,20 @@ def stop(args: Namespace) -> None:
         lambda: console.success(f"{service.name} stopped"),
     ) as status:
         try:
-            run_docker_compose_command(service, "down", mode_dependencies)
+            remote_dependencies = install_and_verify_dependencies(service)
         except DependencyError as de:
             status.failure(str(de))
             exit(1)
+        remote_dependencies = get_non_shared_remote_dependencies(
+            service, remote_dependencies
+        )
+        try:
+            run_docker_compose_command(
+                service,
+                "down",
+                mode_dependencies,
+                remote_dependencies=remote_dependencies,
+            )
         except DockerComposeError as dce:
             status.failure(f"Failed to stop {service.name}: {dce.stderr}")
             exit(1)

--- a/devservices/utils/dependencies.py
+++ b/devservices/utils/dependencies.py
@@ -110,6 +110,23 @@ class GitConfigManager:
             raise FailedToSetGitConfigError from e
 
 
+def install_and_verify_dependencies(
+    service: Service, force_update_dependencies: bool = False
+) -> set[InstalledRemoteDependency]:
+    dependencies = list(service.config.dependencies.values())
+    if force_update_dependencies:
+        remote_dependencies = install_dependencies(dependencies)
+    else:
+        are_dependencies_valid = verify_local_dependencies(dependencies)
+        if not are_dependencies_valid:
+            # TODO: Figure out how to handle this case as installing dependencies may not be the right thing to do
+            #       since the dependencies may have changed since the service was started.
+            remote_dependencies = install_dependencies(dependencies)
+        else:
+            remote_dependencies = get_installed_remote_dependencies(dependencies)
+    return remote_dependencies
+
+
 def verify_local_dependency(remote_config: RemoteConfig) -> bool:
     local_dependency_path = os.path.join(
         DEVSERVICES_DEPENDENCIES_CACHE_DIR,

--- a/devservices/utils/docker_compose.py
+++ b/devservices/utils/docker_compose.py
@@ -224,8 +224,8 @@ def run_docker_compose_command(
     service: Service,
     command: str,
     mode_dependencies: list[str],
+    remote_dependencies: set[InstalledRemoteDependency],
     options: list[str] = [],
-    remote_dependencies: set[InstalledRemoteDependency] = set(),
 ) -> list[subprocess.CompletedProcess[str]]:
     relative_local_dependency_directory = os.path.relpath(
         os.path.join(DEVSERVICES_DEPENDENCIES_CACHE_DIR, DEPENDENCY_CONFIG_VERSION),

--- a/devservices/utils/docker_compose.py
+++ b/devservices/utils/docker_compose.py
@@ -22,11 +22,7 @@ from devservices.exceptions import BinaryInstallError
 from devservices.exceptions import DockerComposeError
 from devservices.exceptions import DockerComposeInstallationError
 from devservices.utils.console import Console
-from devservices.utils.dependencies import get_installed_remote_dependencies
-from devservices.utils.dependencies import get_non_shared_remote_dependencies
-from devservices.utils.dependencies import install_dependencies
 from devservices.utils.dependencies import InstalledRemoteDependency
-from devservices.utils.dependencies import verify_local_dependencies
 from devservices.utils.docker import check_docker_daemon_running
 from devservices.utils.install_binary import install_binary
 from devservices.utils.services import Service
@@ -229,24 +225,8 @@ def run_docker_compose_command(
     command: str,
     mode_dependencies: list[str],
     options: list[str] = [],
-    force_update_dependencies: bool = False,
+    remote_dependencies: set[InstalledRemoteDependency] = set(),
 ) -> list[subprocess.CompletedProcess[str]]:
-    dependencies = list(service.config.dependencies.values())
-    if force_update_dependencies:
-        remote_dependencies = install_dependencies(dependencies)
-    else:
-        are_dependencies_valid = verify_local_dependencies(dependencies)
-        if not are_dependencies_valid:
-            # TODO: Figure out how to handle this case as installing dependencies may not be the right thing to do
-            #       since the dependencies may have changed since the service was started.
-            remote_dependencies = install_dependencies(dependencies)
-        else:
-            remote_dependencies = get_installed_remote_dependencies(dependencies)
-    # TODO: Refactor this to be more generic instead of having a one-off case for stopping
-    if command == "down":
-        remote_dependencies = get_non_shared_remote_dependencies(
-            service, remote_dependencies
-        )
     relative_local_dependency_directory = os.path.relpath(
         os.path.join(DEVSERVICES_DEPENDENCIES_CACHE_DIR, DEPENDENCY_CONFIG_VERSION),
         service.repo_path,


### PR DESCRIPTION
Starting to reduce the complexity of the run_docker_compose_command by decoupling dependency installation logic.