### PR TITLE
fix(debug): Fixing debug flag

### DIFF
--- a/devservices/main.py
+++ b/devservices/main.py
@@ -81,7 +81,7 @@ def main() -> None:
     args = parser.parse_args()
 
     # If the command has a debug flag, set the logger to debug
-    if args.debug:
+    if "debug" in args and args.debug:
         logger = logging.getLogger(LOGGER_NAME)
         logger.setLevel(logging.DEBUG)
 


### PR DESCRIPTION
There was an issue with the namespace, causing certain commands without a debug flag to error out. This changes resolves the issue by making sure the debug flag is in the args beforehand.