### PR TITLE
fix(logs): Fixing bug in logs command, adding tests

### DIFF
--- a/devservices/commands/logs.py
+++ b/devservices/commands/logs.py
@@ -42,8 +42,8 @@ def logs(args: Namespace) -> None:
 
     state = State()
     running_services = state.get_started_services()
-    if service_name not in running_services:
-        console.warning(f"Service {service_name} is not running")
+    if service.name not in running_services:
+        console.warning(f"Service {service.name} is not running")
         return
 
     try:

--- a/tests/commands/test_logs.py
+++ b/tests/commands/test_logs.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import subprocess
+from argparse import Namespace
+from pathlib import Path
+from unittest import mock
+
+import pytest
+
+from devservices.commands.logs import logs
+from devservices.configs.service_config import Dependency
+from devservices.configs.service_config import ServiceConfig
+from devservices.utils.services import Service
+
+
+@mock.patch("devservices.commands.logs.run_docker_compose_command")
+@mock.patch("devservices.commands.logs.find_matching_service")
+@mock.patch("devservices.utils.state.State.get_started_services")
+@mock.patch("devservices.commands.logs.install_and_verify_dependencies")
+def test_logs_no_specified_service_success(
+    mock_install_and_verify_dependencies: mock.Mock,
+    mock_get_started_services: mock.Mock,
+    mock_find_matching_service: mock.Mock,
+    mock_run_docker_compose_command: mock.Mock,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    args = Namespace(service_name=None)
+    mock_service = Service(
+        name="example-service",
+        config=ServiceConfig(
+            version=0.1,
+            service_name="example-service",
+            dependencies={
+                "redis": Dependency(description="Redis"),
+                "clickhouse": Dependency(description="Clickhouse"),
+            },
+            modes={"default": ["redis", "clickhouse"]},
+        ),
+        repo_path=str(tmp_path / "example-service"),
+    )
+    mock_install_and_verify_dependencies.return_value = {}
+    mock_get_started_services.return_value = ["example-service"]
+    mock_find_matching_service.return_value = mock_service
+    mock_run_docker_compose_command.return_value = [
+        subprocess.CompletedProcess(
+            args=["docker", "compose", "logs", "redis", "clickhouse"],
+            returncode=0,
+            stdout="redis and clickhouse log output",
+        )
+    ]
+
+    logs(args)
+
+    mock_install_and_verify_dependencies.assert_called_once()
+    mock_get_started_services.assert_called_once()
+    mock_find_matching_service.assert_called_once_with(None)
+    mock_run_docker_compose_command.assert_called_once_with(
+        mock_service,
+        "logs",
+        ["redis", "clickhouse"],
+        {},
+        options=["-n", "100"],
+    )
+
+    captured = capsys.readouterr()
+    assert captured.out.endswith("redis and clickhouse log output\n")


### PR DESCRIPTION
Fixes a bug where running the logs command without a specified service always fails. Added tests to hopefully catch bugs like this in the future and prevent regressions. Fixes #136 