### PR TITLE
feat(sentry): Adding version tag, cleaning up version logic

### DIFF
--- a/devservices/commands/check_for_update.py
+++ b/devservices/commands/check_for_update.py
@@ -4,7 +4,7 @@ import json
 from urllib.request import urlopen
 
 
-def check_for_update(current_version: str) -> str | None:
+def check_for_update() -> str | None:
     url = "https://api.github.com/repos/getsentry/devservices/releases/latest"
     with urlopen(url) as response:
         if response.status == 200:

--- a/devservices/commands/update.py
+++ b/devservices/commands/update.py
@@ -44,7 +44,7 @@ def add_parser(subparsers: _SubParsersAction[ArgumentParser]) -> None:
 def update(args: Namespace) -> None:
     console = Console()
     current_version = metadata.version("devservices")
-    latest_version = check_for_update(current_version)
+    latest_version = check_for_update()
 
     if latest_version is None:
         raise DevservicesUpdateError("Failed to check for updates.")


### PR DESCRIPTION
Tracking the devservices version via Sentry for better observability. Additionally, I removed some unnecessary code and cleaned up our usage of sentry to import only what we need.