### PR TITLE
ref(docker-compose): De-abstracting run_docker_compose_command

### DIFF
--- a/devservices/commands/logs.py
+++ b/devservices/commands/logs.py
@@ -1,18 +1,29 @@
 from __future__ import annotations
 
+import concurrent.futures
+import os
+import subprocess
 from argparse import _SubParsersAction
 from argparse import ArgumentParser
 from argparse import Namespace
 
 from sentry_sdk import capture_exception
 
+from devservices.constants import CONFIG_FILE_NAME
+from devservices.constants import DEPENDENCY_CONFIG_VERSION
+from devservices.constants import DEVSERVICES_DEPENDENCIES_CACHE_DIR
+from devservices.constants import DEVSERVICES_DEPENDENCIES_CACHE_DIR_KEY
+from devservices.constants import DEVSERVICES_DIR_NAME
 from devservices.constants import MAX_LOG_LINES
 from devservices.exceptions import DependencyError
 from devservices.exceptions import DockerComposeError
 from devservices.utils.console import Console
 from devservices.utils.dependencies import install_and_verify_dependencies
-from devservices.utils.docker_compose import run_docker_compose_command
+from devservices.utils.dependencies import InstalledRemoteDependency
+from devservices.utils.docker_compose import get_docker_compose_commands_to_run
+from devservices.utils.docker_compose import run_cmd
 from devservices.utils.services import find_matching_service
+from devservices.utils.services import Service
 from devservices.utils.state import State
 
 
@@ -56,13 +67,7 @@ def logs(args: Namespace) -> None:
         console.failure(str(de))
         exit(1)
     try:
-        logs_output = run_docker_compose_command(
-            service,
-            "logs",
-            mode_dependencies,
-            remote_dependencies,
-            options=["-n", MAX_LOG_LINES],
-        )
+        logs_output = _logs(service, remote_dependencies, mode_dependencies)
     except DockerComposeError as dce:
         capture_exception(dce)
         console.failure(f"Failed to get logs for {service.name}: {dce.stderr}")
@@ -71,3 +76,43 @@ def logs(args: Namespace) -> None:
         log_stdout: str | None = log.stdout
         if log_stdout is not None:
             console.info(log_stdout)
+
+
+def _logs(
+    service: Service,
+    remote_dependencies: set[InstalledRemoteDependency],
+    mode_dependencies: list[str],
+) -> list[subprocess.CompletedProcess[str]]:
+    relative_local_dependency_directory = os.path.relpath(
+        os.path.join(DEVSERVICES_DEPENDENCIES_CACHE_DIR, DEPENDENCY_CONFIG_VERSION),
+        service.repo_path,
+    )
+    service_config_file_path = os.path.join(
+        service.repo_path, DEVSERVICES_DIR_NAME, CONFIG_FILE_NAME
+    )
+    # Set the environment variable for the local dependencies directory to be used by docker compose
+    current_env = os.environ.copy()
+    current_env[
+        DEVSERVICES_DEPENDENCIES_CACHE_DIR_KEY
+    ] = relative_local_dependency_directory
+    docker_compose_commands = get_docker_compose_commands_to_run(
+        service=service,
+        remote_dependencies=remote_dependencies,
+        current_env=current_env,
+        command="logs",
+        options=["-n", MAX_LOG_LINES],
+        service_config_file_path=service_config_file_path,
+        mode_dependencies=mode_dependencies,
+    )
+
+    cmd_outputs = []
+
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        futures = [
+            executor.submit(run_cmd, cmd, current_env)
+            for cmd in docker_compose_commands
+        ]
+        for future in concurrent.futures.as_completed(futures):
+            cmd_outputs.append(future.result())
+
+    return cmd_outputs

--- a/devservices/commands/start.py
+++ b/devservices/commands/start.py
@@ -1,18 +1,28 @@
 from __future__ import annotations
 
+import concurrent.futures
+import os
 from argparse import _SubParsersAction
 from argparse import ArgumentParser
 from argparse import Namespace
 
 from sentry_sdk import capture_exception
 
+from devservices.constants import CONFIG_FILE_NAME
+from devservices.constants import DEPENDENCY_CONFIG_VERSION
+from devservices.constants import DEVSERVICES_DEPENDENCIES_CACHE_DIR
+from devservices.constants import DEVSERVICES_DEPENDENCIES_CACHE_DIR_KEY
+from devservices.constants import DEVSERVICES_DIR_NAME
 from devservices.exceptions import DependencyError
 from devservices.exceptions import DockerComposeError
 from devservices.utils.console import Console
 from devservices.utils.console import Status
 from devservices.utils.dependencies import install_and_verify_dependencies
-from devservices.utils.docker_compose import run_docker_compose_command
+from devservices.utils.dependencies import InstalledRemoteDependency
+from devservices.utils.docker_compose import get_docker_compose_commands_to_run
+from devservices.utils.docker_compose import run_cmd
 from devservices.utils.services import find_matching_service
+from devservices.utils.services import Service
 from devservices.utils.state import State
 
 
@@ -59,13 +69,7 @@ def start(args: Namespace) -> None:
             status.failure(str(de))
             exit(1)
         try:
-            run_docker_compose_command(
-                service,
-                "up",
-                mode_dependencies,
-                remote_dependencies,
-                options=["-d", "--wait"],
-            )
+            _start(service, remote_dependencies, mode_dependencies)
         except DockerComposeError as dce:
             capture_exception(dce)
             status.failure(f"Failed to start {service.name}: {dce.stderr}")
@@ -73,3 +77,41 @@ def start(args: Namespace) -> None:
     # TODO: We should factor in healthchecks here before marking service as running
     state = State()
     state.add_started_service(service.name, mode_to_start)
+
+
+def _start(
+    service: Service,
+    remote_dependencies: set[InstalledRemoteDependency],
+    mode_dependencies: list[str],
+) -> None:
+    relative_local_dependency_directory = os.path.relpath(
+        os.path.join(DEVSERVICES_DEPENDENCIES_CACHE_DIR, DEPENDENCY_CONFIG_VERSION),
+        service.repo_path,
+    )
+    service_config_file_path = os.path.join(
+        service.repo_path, DEVSERVICES_DIR_NAME, CONFIG_FILE_NAME
+    )
+    # Set the environment variable for the local dependencies directory to be used by docker compose
+    current_env = os.environ.copy()
+    current_env[
+        DEVSERVICES_DEPENDENCIES_CACHE_DIR_KEY
+    ] = relative_local_dependency_directory
+    docker_compose_commands = get_docker_compose_commands_to_run(
+        service=service,
+        remote_dependencies=remote_dependencies,
+        current_env=current_env,
+        command="up",
+        options=["-d", "--wait"],
+        service_config_file_path=service_config_file_path,
+        mode_dependencies=mode_dependencies,
+    )
+
+    cmd_outputs = []
+
+    with concurrent.futures.ThreadPoolExecutor() as executor:
+        futures = [
+            executor.submit(run_cmd, cmd, current_env)
+            for cmd in docker_compose_commands
+        ]
+        for future in concurrent.futures.as_completed(futures):
+            cmd_outputs.append(future.result())

--- a/tests/commands/test_start.py
+++ b/tests/commands/test_start.py
@@ -30,7 +30,7 @@ def test_start_simple(
     mock_add_started_service: mock.Mock, mock_run: mock.Mock, tmp_path: Path
 ) -> None:
     with mock.patch(
-        "devservices.utils.docker_compose.DEVSERVICES_DEPENDENCIES_CACHE_DIR",
+        "devservices.commands.start.DEVSERVICES_DEPENDENCIES_CACHE_DIR",
         str(tmp_path / "dependency-dir"),
     ):
         config = {

--- a/tests/commands/test_stop.py
+++ b/tests/commands/test_stop.py
@@ -30,7 +30,7 @@ def test_stop_simple(
     mock_remove_started_service: mock.Mock, mock_run: mock.Mock, tmp_path: Path
 ) -> None:
     with mock.patch(
-        "devservices.utils.docker_compose.DEVSERVICES_DEPENDENCIES_CACHE_DIR",
+        "devservices.commands.stop.DEVSERVICES_DEPENDENCIES_CACHE_DIR",
         str(tmp_path / "dependency-dir"),
     ):
         config = {

--- a/tests/utils/test_docker_compose.py
+++ b/tests/utils/test_docker_compose.py
@@ -15,9 +15,9 @@ from devservices.exceptions import DockerComposeError
 from devservices.exceptions import DockerComposeInstallationError
 from devservices.exceptions import DockerDaemonNotRunningError
 from devservices.utils.dependencies import InstalledRemoteDependency
-from devservices.utils.docker_compose import _get_docker_compose_commands_to_run
 from devservices.utils.docker_compose import _get_non_remote_services
 from devservices.utils.docker_compose import check_docker_compose_version
+from devservices.utils.docker_compose import get_docker_compose_commands_to_run
 from devservices.utils.docker_compose import install_docker_compose
 from devservices.utils.services import Service
 from testing.utils import create_mock_git_repo
@@ -288,7 +288,7 @@ def test_get_all_commands_to_run_simple_local(
         repo_path=child_service_repo_path_str,
         config=service_config,
     )
-    commands = _get_docker_compose_commands_to_run(
+    commands = get_docker_compose_commands_to_run(
         service=service,
         remote_dependencies=remote_dependencies,
         current_env=current_env,
@@ -341,7 +341,7 @@ def test_get_all_commands_to_run_no_services_to_use(
         repo_path=child_service_repo_path_str,
         config=service_config,
     )
-    commands = _get_docker_compose_commands_to_run(
+    commands = get_docker_compose_commands_to_run(
         service=service,
         remote_dependencies=remote_dependencies,
         current_env=current_env,
@@ -398,7 +398,7 @@ def test_get_all_commands_to_run_simple_remote(
             stdout="parent-service\n",
         ),
     ]
-    commands = _get_docker_compose_commands_to_run(
+    commands = get_docker_compose_commands_to_run(
         service=service,
         remote_dependencies=remote_dependencies,
         current_env=current_env,
@@ -495,7 +495,7 @@ def test_get_all_commands_to_run_complex_remote(
             stdout="grandparent-service\n",
         ),
     ]
-    commands = _get_docker_compose_commands_to_run(
+    commands = get_docker_compose_commands_to_run(
         service=service,
         remote_dependencies=remote_dependencies,
         current_env=current_env,


### PR DESCRIPTION
Fixes https://github.com/getsentry/devservices/issues/109. While it seemed nice to abstract out a lot of the logic initially, it has made command specific logic difficult to deal with, slowing down development. While this change looks like a step backward, it should improve development going forward as we are no longer bound by a function that does way too much.