### PR TITLE
ref(purge): removing docker networks with purge

### DIFF
--- a/devservices/commands/purge.py
+++ b/devservices/commands/purge.py
@@ -2,11 +2,13 @@ from __future__ import annotations
 
 import os
 import shutil
+import subprocess
 from argparse import _SubParsersAction
 from argparse import ArgumentParser
 from argparse import Namespace
 
 from devservices.constants import DEVSERVICES_CACHE_DIR
+from devservices.constants import DOCKER_NETWORK_NAME
 from devservices.exceptions import DockerDaemonNotRunningError
 from devservices.utils.console import Console
 from devservices.utils.console import Status
@@ -22,6 +24,7 @@ def add_parser(subparsers: _SubParsersAction[ArgumentParser]) -> None:
 def purge(args: Namespace) -> None:
     """Purge the local devservices cache."""
     console = Console()
+
     # Prompt the user to stop all running containers
     should_stop_containers = console.confirm(
         "Warning: Purging stops all running containers and clears devservices state. Would you like to continue?"
@@ -46,5 +49,33 @@ def purge(args: Namespace) -> None:
             stop_all_running_containers()
         except DockerDaemonNotRunningError:
             console.warning("The docker daemon not running, no containers to stop")
+
+    console.warning("Removing any devservices networks")
+    devservices_networks = (
+        subprocess.check_output(
+            [
+                "docker",
+                "network",
+                "ls",
+                "--filter",
+                f"name={DOCKER_NETWORK_NAME}",
+                "--format",
+                "{{.ID}}",
+            ]
+        )
+        .decode()
+        .strip()
+        .splitlines()
+    )
+    if len(devservices_networks) == 0:
+        console.success("No devservices networks found to remove")
+    for network in devservices_networks:
+        subprocess.run(
+            ["docker", "network", "rm", network],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        console.success(f"Network {network} removed")
 
     console.success("The local devservices cache and state has been purged")

--- a/devservices/constants.py
+++ b/devservices/constants.py
@@ -25,3 +25,4 @@ DEVSERVICES_DOWNLOAD_URL = "https://github.com/getsentry/devservices/releases/do
 BINARY_PERMISSIONS = 0o755
 MAX_LOG_LINES = "100"
 LOGGER_NAME = "devservices"
+DOCKER_NETWORK_NAME = "devservices"


### PR DESCRIPTION
We hit some issues with race conditions and multiple instances of the same docker network being created. While we are going to fix that issue separately, we should also be able to clear the docker networks as a backup.