### PR TITLE
ref(dependencies): Updating dependency management to handle modes

### DIFF
--- a/devservices/exceptions.py
+++ b/devservices/exceptions.py
@@ -67,6 +67,16 @@ class DockerComposeError(Exception):
         self.stderr = stderr
 
 
+class ModeDoesNotExistError(Exception):
+    """Raised when a mode does not exist."""
+
+    def __init__(self, mode: str):
+        self.mode = mode
+
+    def __str__(self) -> str:
+        return f"ModeDoesNotExistError: Mode '{self.mode}' does not exist"
+
+
 class DependencyError(Exception):
     """Base class for dependency-related errors."""
 

--- a/devservices/exceptions.py
+++ b/devservices/exceptions.py
@@ -70,11 +70,12 @@ class DockerComposeError(Exception):
 class ModeDoesNotExistError(Exception):
     """Raised when a mode does not exist."""
 
-    def __init__(self, mode: str):
+    def __init__(self, service_name: str, mode: str):
+        self.service_name = service_name
         self.mode = mode
 
     def __str__(self) -> str:
-        return f"ModeDoesNotExistError: Mode '{self.mode}' does not exist"
+        return f"ModeDoesNotExistError: Mode '{self.mode}' does not exist for service '{self.service_name}'"
 
 
 class DependencyError(Exception):

--- a/devservices/utils/dependencies.py
+++ b/devservices/utils/dependencies.py
@@ -27,6 +27,7 @@ from devservices.exceptions import DependencyError
 from devservices.exceptions import DependencyNotInstalledError
 from devservices.exceptions import FailedToSetGitConfigError
 from devservices.exceptions import InvalidDependencyConfigError
+from devservices.exceptions import ModeDoesNotExistError
 from devservices.exceptions import UnableToCloneDependencyError
 from devservices.utils.file_lock import lock
 from devservices.utils.services import find_matching_service
@@ -101,19 +102,29 @@ class GitConfigManager:
 
 
 def install_and_verify_dependencies(
-    service: Service, force_update_dependencies: bool = False
+    service: Service, force_update_dependencies: bool = False, mode: str = "default"
 ) -> set[InstalledRemoteDependency]:
-    dependencies = list(service.config.dependencies.values())
+    if mode not in service.config.modes:
+        raise ModeDoesNotExistError(mode=mode)
+    mode_dependencies = set(service.config.modes[mode])
+    matching_dependencies = [
+        dependency
+        for dependency_key, dependency in list(service.config.dependencies.items())
+        if dependency_key in mode_dependencies
+    ]
+
     if force_update_dependencies:
-        remote_dependencies = install_dependencies(dependencies)
+        remote_dependencies = install_dependencies(matching_dependencies)
     else:
-        are_dependencies_valid = verify_local_dependencies(dependencies)
+        are_dependencies_valid = verify_local_dependencies(matching_dependencies)
         if not are_dependencies_valid:
             # TODO: Figure out how to handle this case as installing dependencies may not be the right thing to do
             #       since the dependencies may have changed since the service was started.
-            remote_dependencies = install_dependencies(dependencies)
+            remote_dependencies = install_dependencies(matching_dependencies)
         else:
-            remote_dependencies = get_installed_remote_dependencies(dependencies)
+            remote_dependencies = get_installed_remote_dependencies(
+                matching_dependencies
+            )
     return remote_dependencies
 
 

--- a/devservices/utils/dependencies.py
+++ b/devservices/utils/dependencies.py
@@ -105,7 +105,7 @@ def install_and_verify_dependencies(
     service: Service, force_update_dependencies: bool = False, mode: str = "default"
 ) -> set[InstalledRemoteDependency]:
     if mode not in service.config.modes:
-        raise ModeDoesNotExistError(mode=mode)
+        raise ModeDoesNotExistError(service_name=service.name, mode=mode)
     mode_dependencies = set(service.config.modes[mode])
     matching_dependencies = [
         dependency


### PR DESCRIPTION
Currently, our dependency logic installs and returns all dependencies rather than just those needed for a specific mode. This PR changes that to be more efficient and accurate.