### PR TITLE
feat(devservices): Support modes for up/down

### DIFF
--- a/devservices/commands/down.py
+++ b/devservices/commands/down.py
@@ -60,9 +60,6 @@ def down(args: Namespace) -> None:
         exit(1)
 
     modes = service.config.modes
-    # TODO: allow custom modes to be used
-    mode = "default"
-    mode_dependencies = modes[mode]
 
     state = State()
     started_services = state.get_started_services()
@@ -70,12 +67,15 @@ def down(args: Namespace) -> None:
         console.warning(f"{service.name} is not running")
         exit(0)
 
+    mode = state.get_mode_for_service(service.name) or "default"
+    mode_dependencies = modes[mode]
+
     with Status(
         lambda: console.warning(f"Stopping {service.name}"),
         lambda: console.success(f"{service.name} stopped"),
     ) as status:
         try:
-            remote_dependencies = install_and_verify_dependencies(service)
+            remote_dependencies = install_and_verify_dependencies(service, mode=mode)
         except DependencyError as de:
             capture_exception(de)
             status.failure(str(de))

--- a/devservices/commands/up.py
+++ b/devservices/commands/up.py
@@ -17,6 +17,7 @@ from devservices.constants import DEVSERVICES_DIR_NAME
 from devservices.constants import DOCKER_COMPOSE_COMMAND_LENGTH
 from devservices.exceptions import DependencyError
 from devservices.exceptions import DockerComposeError
+from devservices.exceptions import ModeDoesNotExistError
 from devservices.utils.console import Console
 from devservices.utils.console import Status
 from devservices.utils.dependencies import install_and_verify_dependencies
@@ -39,6 +40,11 @@ def add_parser(subparsers: _SubParsersAction[ArgumentParser]) -> None:
         action="store_true",
         default=False,
     )
+    parser.add_argument(
+        "--mode",
+        help="Mode to use for the service",
+        default="default",
+    )
     parser.set_defaults(func=up)
 
 
@@ -54,9 +60,7 @@ def up(args: Namespace) -> None:
         exit(1)
 
     modes = service.config.modes
-    # TODO: allow custom modes to be used
-    mode = "default"
-    mode_dependencies = modes[mode]
+    mode = args.mode
 
     with Status(
         lambda: console.warning(f"Starting {service.name}"),
@@ -65,13 +69,17 @@ def up(args: Namespace) -> None:
         try:
             status.info("Retrieving dependencies")
             remote_dependencies = install_and_verify_dependencies(
-                service, force_update_dependencies=True
+                service, force_update_dependencies=True, mode=mode
             )
         except DependencyError as de:
             capture_exception(de)
             status.failure(str(de))
             exit(1)
+        except ModeDoesNotExistError as mde:
+            status.failure(str(mde))
+            exit(1)
         try:
+            mode_dependencies = modes[mode]
             _up(service, remote_dependencies, mode_dependencies, status)
         except DockerComposeError as dce:
             capture_exception(dce)

--- a/tests/commands/test_up.py
+++ b/tests/commands/test_up.py
@@ -58,7 +58,7 @@ def test_up_simple(
         create_config_file(service_path, config)
         os.chdir(service_path)
 
-        args = Namespace(service_name=None, debug=False)
+        args = Namespace(service_name=None, debug=False, mode="default")
 
         up(args)
 
@@ -131,7 +131,7 @@ def test_up_dependency_error(
         create_config_file(tmp_path, config)
         os.chdir(tmp_path)
 
-        args = Namespace(service_name=None, debug=False)
+        args = Namespace(service_name=None, debug=False, mode="default")
 
         with pytest.raises(SystemExit):
             up(args)
@@ -181,7 +181,7 @@ def test_up_error(
     create_config_file(tmp_path, config)
     os.chdir(tmp_path)
 
-    args = Namespace(service_name=None, debug=False)
+    args = Namespace(service_name=None, debug=False, mode="default")
 
     with pytest.raises(SystemExit):
         up(args)
@@ -199,3 +199,142 @@ def test_up_error(
     assert "Retrieving dependencies" not in captured.out.strip()
     assert "Starting clickhouse" not in captured.out.strip()
     assert "Starting redis" not in captured.out.strip()
+
+
+@mock.patch(
+    "devservices.utils.docker_compose.subprocess.run",
+    return_value=subprocess.CompletedProcess(
+        args=["docker", "compose", "config", "--services"],
+        returncode=0,
+        stdout="clickhouse\nredis\n",
+    ),
+)
+@mock.patch("devservices.utils.state.State.add_started_service")
+def test_up_mode_simple(
+    mock_add_started_service: mock.Mock,
+    mock_run: mock.Mock,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with mock.patch(
+        "devservices.commands.up.DEVSERVICES_DEPENDENCIES_CACHE_DIR",
+        str(tmp_path / "dependency-dir"),
+    ):
+        config = {
+            "x-sentry-service-config": {
+                "version": 0.1,
+                "service_name": "example-service",
+                "dependencies": {
+                    "redis": {"description": "Redis"},
+                    "clickhouse": {"description": "Clickhouse"},
+                },
+                "modes": {"default": ["redis", "clickhouse"], "test": ["redis"]},
+            },
+            "services": {
+                "redis": {"image": "redis:6.2.14-alpine"},
+                "clickhouse": {
+                    "image": "altinity/clickhouse-server:23.8.11.29.altinitystable"
+                },
+            },
+        }
+
+        service_path = tmp_path / "example-service"
+        create_config_file(service_path, config)
+        os.chdir(service_path)
+
+        args = Namespace(service_name=None, debug=False, mode="test")
+
+        up(args)
+
+        # Ensure the DEVSERVICES_DEPENDENCIES_CACHE_DIR_KEY is set and is relative
+        env_vars = mock_run.call_args[1]["env"]
+        assert (
+            env_vars[DEVSERVICES_DEPENDENCIES_CACHE_DIR_KEY]
+            == f"../dependency-dir/{DEPENDENCY_CONFIG_VERSION}"
+        )
+
+        mock_run.assert_called_with(
+            [
+                "docker",
+                "compose",
+                "-p",
+                "example-service",
+                "-f",
+                f"{service_path}/{DEVSERVICES_DIR_NAME}/{CONFIG_FILE_NAME}",
+                "up",
+                "redis",
+                "-d",
+                "--wait",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=mock.ANY,
+        )
+
+        mock_add_started_service.assert_called_with("example-service", "test")
+        captured = capsys.readouterr()
+        assert "Retrieving dependencies" in captured.out.strip()
+        assert "Starting redis" in captured.out.strip()
+
+
+@mock.patch(
+    "devservices.utils.docker_compose.subprocess.run",
+    return_value=subprocess.CompletedProcess(
+        args=["docker", "compose", "config", "--services"],
+        returncode=0,
+        stdout="clickhouse\nredis\n",
+    ),
+)
+@mock.patch("devservices.utils.state.State.add_started_service")
+def test_up_mode_does_not_exist(
+    mock_add_started_service: mock.Mock,
+    mock_run: mock.Mock,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with mock.patch(
+        "devservices.commands.up.DEVSERVICES_DEPENDENCIES_CACHE_DIR",
+        str(tmp_path / "dependency-dir"),
+    ):
+        config = {
+            "x-sentry-service-config": {
+                "version": 0.1,
+                "service_name": "example-service",
+                "dependencies": {
+                    "redis": {"description": "Redis"},
+                    "clickhouse": {"description": "Clickhouse"},
+                },
+                "modes": {"default": ["redis", "clickhouse"]},
+            },
+            "services": {
+                "redis": {"image": "redis:6.2.14-alpine"},
+                "clickhouse": {
+                    "image": "altinity/clickhouse-server:23.8.11.29.altinitystable"
+                },
+            },
+        }
+
+        service_path = tmp_path / "example-service"
+        create_config_file(service_path, config)
+        os.chdir(service_path)
+
+        args = Namespace(service_name=None, debug=False, mode="test")
+
+        with pytest.raises(SystemExit):
+            up(args)
+
+        # Capture the printed output
+        captured = capsys.readouterr()
+
+        assert (
+            "ModeDoesNotExistError: Mode 'test' does not exist for service 'example-service'"
+            in captured.out.strip()
+        )
+
+        mock_add_started_service.assert_not_called()
+
+        captured = capsys.readouterr()
+        assert "Retrieving dependencies" not in captured.out.strip()
+        assert "Starting clickhouse" not in captured.out.strip()
+        assert "Starting redis" not in captured.out.strip()

--- a/tests/utils/test_dependencies.py
+++ b/tests/utils/test_dependencies.py
@@ -18,11 +18,9 @@ from devservices.exceptions import DependencyError
 from devservices.exceptions import DependencyNotInstalledError
 from devservices.exceptions import FailedToSetGitConfigError
 from devservices.exceptions import InvalidDependencyConfigError
-from devservices.exceptions import ModeDoesNotExistError
 from devservices.utils.dependencies import get_installed_remote_dependencies
 from devservices.utils.dependencies import get_non_shared_remote_dependencies
 from devservices.utils.dependencies import GitConfigManager
-from devservices.utils.dependencies import install_and_verify_dependencies
 from devservices.utils.dependencies import install_dependencies
 from devservices.utils.dependencies import install_dependency
 from devservices.utils.dependencies import InstalledRemoteDependency
@@ -1466,117 +1464,3 @@ def test_get_non_shared_remote_dependencies_complex(
             mode="default",
         )
     }
-
-
-@mock.patch("devservices.utils.dependencies.install_dependencies", return_value=[])
-def test_install_and_verify_dependencies_simple(
-    mock_install_dependencies: mock.Mock, tmp_path: Path
-) -> None:
-    service = Service(
-        name="test-service",
-        repo_path="/path/to/test-service",
-        config=ServiceConfig(
-            version=0.1,
-            service_name="test-service",
-            dependencies={
-                "dependency-1": Dependency(
-                    description="dependency-1",
-                    remote=RemoteConfig(
-                        repo_name="dependency-1",
-                        repo_link="file://path/to/dependency-1",
-                        branch="main",
-                    ),
-                ),
-                "dependency-2": Dependency(
-                    description="dependency-2",
-                    remote=RemoteConfig(
-                        repo_name="dependency-2",
-                        repo_link="file://path/to/dependency-2",
-                        branch="main",
-                    ),
-                ),
-            },
-            modes={"default": ["dependency-1", "dependency-2"]},
-        ),
-    )
-    install_and_verify_dependencies(service)
-
-    mock_install_dependencies.assert_called_once_with(
-        [
-            service.config.dependencies["dependency-1"],
-            service.config.dependencies["dependency-2"],
-        ]
-    )
-
-
-@mock.patch("devservices.utils.dependencies.install_dependencies", return_value=[])
-def test_install_and_verify_dependencies_mode_simple(
-    mock_install_dependencies: mock.Mock, tmp_path: Path
-) -> None:
-    service = Service(
-        name="test-service",
-        repo_path="/path/to/test-service",
-        config=ServiceConfig(
-            version=0.1,
-            service_name="test-service",
-            dependencies={
-                "dependency-1": Dependency(
-                    description="dependency-1",
-                    remote=RemoteConfig(
-                        repo_name="dependency-1",
-                        repo_link="file://path/to/dependency-1",
-                        branch="main",
-                    ),
-                ),
-                "dependency-2": Dependency(
-                    description="dependency-2",
-                    remote=RemoteConfig(
-                        repo_name="dependency-2",
-                        repo_link="file://path/to/dependency-2",
-                        branch="main",
-                    ),
-                ),
-            },
-            modes={
-                "default": ["dependency-1", "dependency-2"],
-                "test": ["dependency-1"],
-            },
-        ),
-    )
-    install_and_verify_dependencies(service, mode="test")
-
-    mock_install_dependencies.assert_called_once_with(
-        [service.config.dependencies["dependency-1"]]
-    )
-
-
-def test_install_and_verify_dependencies_mode_does_not_exist(tmp_path: Path) -> None:
-    with pytest.raises(ModeDoesNotExistError):
-        service = Service(
-            name="test-service",
-            repo_path="/path/to/test-service",
-            config=ServiceConfig(
-                version=0.1,
-                service_name="test-service",
-                dependencies={
-                    "dependency-1": Dependency(
-                        description="dependency-1",
-                        remote=RemoteConfig(
-                            repo_name="dependency-1",
-                            repo_link="file://path/to/dependency-1",
-                            branch="main",
-                        ),
-                    ),
-                    "dependency-2": Dependency(
-                        description="dependency-2",
-                        remote=RemoteConfig(
-                            repo_name="dependency-2",
-                            repo_link="file://path/to/dependency-2",
-                            branch="main",
-                        ),
-                    ),
-                },
-                modes={"default": ["dependency-1", "dependency-2"]},
-            ),
-        )
-        install_and_verify_dependencies(service, mode="unknown-mode")


### PR DESCRIPTION
This PR adds support for modes for `devservices up` and `devservices down`.

The mode will be passed in as an option --mode

`devservices start sentry --mode migrations`

When running `devservices down` on a service, the mode will automatically be detected to bring a service down. If for some reason state is corrupted, devservices will try to bring down all the dependencies defined in the `default` mode. 