### PR TITLE
fix(purge): Fixing purge test

### DIFF
--- a/tests/commands/test_purge.py
+++ b/tests/commands/test_purge.py
@@ -28,8 +28,9 @@ def test_purge_not_confirmed(
 
 
 @mock.patch("devservices.commands.purge.stop_all_running_containers")
+@mock.patch("devservices.commands.purge.subprocess.run")
 def test_purge_with_cache_and_state_and_no_running_containers_confirmed(
-    mock_stop_all_running_containers: mock.Mock, tmp_path: Path
+    mock_run: mock.Mock, mock_stop_all_running_containers: mock.Mock, tmp_path: Path
 ) -> None:
     with (
         mock.patch(
@@ -40,6 +41,10 @@ def test_purge_with_cache_and_state_and_no_running_containers_confirmed(
         mock.patch.object(builtins, "input", lambda _: "yes"),
         mock.patch(
             "devservices.utils.docker.check_docker_daemon_running", return_value=None
+        ),
+        mock.patch(
+            "devservices.commands.purge.subprocess.check_output",
+            return_value=b"",
         ),
     ):
         # Create a cache file to test purging
@@ -61,6 +66,7 @@ def test_purge_with_cache_and_state_and_no_running_containers_confirmed(
         assert state.get_started_services() == []
 
         mock_stop_all_running_containers.assert_called_once()
+        mock_run.assert_not_called()
 
 
 @mock.patch("devservices.commands.purge.stop_all_running_containers")


### PR DESCRIPTION
Not sure how this slipped by, but I am pretty sure this was destined to fail once run with devservices running in the background since it would try to remove the network.