### PR TITLE
ref(commands): Cleaning up error handling for commands

### DIFF
--- a/devservices/commands/down.py
+++ b/devservices/commands/down.py
@@ -15,8 +15,10 @@ from devservices.constants import DEVSERVICES_DEPENDENCIES_CACHE_DIR
 from devservices.constants import DEVSERVICES_DEPENDENCIES_CACHE_DIR_KEY
 from devservices.constants import DEVSERVICES_DIR_NAME
 from devservices.constants import DOCKER_COMPOSE_COMMAND_LENGTH
+from devservices.exceptions import ConfigError
 from devservices.exceptions import DependencyError
 from devservices.exceptions import DockerComposeError
+from devservices.exceptions import ServiceNotFoundError
 from devservices.utils.console import Console
 from devservices.utils.console import Status
 from devservices.utils.dependencies import get_non_shared_remote_dependencies
@@ -54,7 +56,7 @@ def down(args: Namespace) -> None:
     service_name = args.service_name
     try:
         service = find_matching_service(service_name)
-    except Exception as e:
+    except (ConfigError, ServiceNotFoundError) as e:
         capture_exception(e)
         console.failure(str(e))
         exit(1)

--- a/devservices/commands/list_dependencies.py
+++ b/devservices/commands/list_dependencies.py
@@ -6,6 +6,8 @@ from argparse import Namespace
 
 from sentry_sdk import capture_exception
 
+from devservices.exceptions import ConfigError
+from devservices.exceptions import ServiceNotFoundError
 from devservices.utils.console import Console
 from devservices.utils.services import find_matching_service
 
@@ -30,7 +32,7 @@ def list_dependencies(args: Namespace) -> None:
 
     try:
         service = find_matching_service(service_name)
-    except Exception as e:
+    except (ConfigError, ServiceNotFoundError) as e:
         capture_exception(e)
         console.failure(str(e))
         exit(1)

--- a/devservices/commands/logs.py
+++ b/devservices/commands/logs.py
@@ -15,8 +15,10 @@ from devservices.constants import DEVSERVICES_DEPENDENCIES_CACHE_DIR
 from devservices.constants import DEVSERVICES_DEPENDENCIES_CACHE_DIR_KEY
 from devservices.constants import DEVSERVICES_DIR_NAME
 from devservices.constants import MAX_LOG_LINES
+from devservices.exceptions import ConfigError
 from devservices.exceptions import DependencyError
 from devservices.exceptions import DockerComposeError
+from devservices.exceptions import ServiceNotFoundError
 from devservices.utils.console import Console
 from devservices.utils.dependencies import install_and_verify_dependencies
 from devservices.utils.dependencies import InstalledRemoteDependency
@@ -44,7 +46,7 @@ def logs(args: Namespace) -> None:
     service_name = args.service_name
     try:
         service = find_matching_service(service_name)
-    except Exception as e:
+    except (ConfigError, ServiceNotFoundError) as e:
         capture_exception(e)
         console.failure(str(e))
         exit(1)

--- a/devservices/commands/status.py
+++ b/devservices/commands/status.py
@@ -15,8 +15,10 @@ from devservices.constants import DEPENDENCY_CONFIG_VERSION
 from devservices.constants import DEVSERVICES_DEPENDENCIES_CACHE_DIR
 from devservices.constants import DEVSERVICES_DEPENDENCIES_CACHE_DIR_KEY
 from devservices.constants import DEVSERVICES_DIR_NAME
+from devservices.exceptions import ConfigError
 from devservices.exceptions import DependencyError
 from devservices.exceptions import DockerComposeError
+from devservices.exceptions import ServiceNotFoundError
 from devservices.utils.console import Console
 from devservices.utils.dependencies import install_and_verify_dependencies
 from devservices.utils.dependencies import InstalledRemoteDependency
@@ -79,7 +81,7 @@ def status(args: Namespace) -> None:
     service_name = args.service_name
     try:
         service = find_matching_service(service_name)
-    except Exception as e:
+    except (ConfigError, ServiceNotFoundError) as e:
         capture_exception(e)
         console.failure(str(e))
         exit(1)

--- a/devservices/commands/up.py
+++ b/devservices/commands/up.py
@@ -15,8 +15,10 @@ from devservices.constants import DEVSERVICES_DEPENDENCIES_CACHE_DIR
 from devservices.constants import DEVSERVICES_DEPENDENCIES_CACHE_DIR_KEY
 from devservices.constants import DEVSERVICES_DIR_NAME
 from devservices.constants import DOCKER_COMPOSE_COMMAND_LENGTH
+from devservices.exceptions import ConfigError
 from devservices.exceptions import DependencyError
 from devservices.exceptions import DockerComposeError
+from devservices.exceptions import ServiceNotFoundError
 from devservices.utils.console import Console
 from devservices.utils.console import Status
 from devservices.utils.dependencies import install_and_verify_dependencies
@@ -48,7 +50,7 @@ def up(args: Namespace) -> None:
     service_name = args.service_name
     try:
         service = find_matching_service(service_name)
-    except Exception as e:
+    except (ConfigError, ServiceNotFoundError) as e:
         capture_exception(e)
         console.failure(str(e))
         exit(1)


### PR DESCRIPTION
Currently, we have very broad error handling for finding matching services in most commands. This change updates the error  handling to be more specific and targeted.