### PR TITLE
fix(commands): Cleaning up unused args

### DIFF
--- a/devservices/commands/purge.py
+++ b/devservices/commands/purge.py
@@ -21,7 +21,7 @@ def add_parser(subparsers: _SubParsersAction[ArgumentParser]) -> None:
     parser.set_defaults(func=purge)
 
 
-def purge(args: Namespace) -> None:
+def purge(_args: Namespace) -> None:
     """Purge the local devservices cache."""
     console = Console()
 

--- a/devservices/commands/update.py
+++ b/devservices/commands/update.py
@@ -41,7 +41,7 @@ def add_parser(subparsers: _SubParsersAction[ArgumentParser]) -> None:
     parser.set_defaults(func=update)
 
 
-def update(args: Namespace) -> None:
+def update(_args: Namespace) -> None:
     console = Console()
     current_version = metadata.version("devservices")
     latest_version = check_for_update()


### PR DESCRIPTION
Prefixing unused args with an underscore to make my linter happy.