### PR TITLE
fix(up): Remove capture output flag when creating devservices network

### DIFF
--- a/devservices/commands/up.py
+++ b/devservices/commands/up.py
@@ -141,7 +141,6 @@ def _up(
 def _create_devservices_network() -> None:
     subprocess.run(
         ["docker", "network", "create", "devservices"],
-        capture_output=True,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )


### PR DESCRIPTION
Fixes: `ValueError: stdout and stderr arguments may not be used with capture_output.`