### PR TITLE
feat(dependency): Adding dependency graph to start services

### DIFF
--- a/devservices/commands/down.py
+++ b/devservices/commands/down.py
@@ -126,7 +126,7 @@ def _down(
     ] = relative_local_dependency_directory
     docker_compose_commands = get_docker_compose_commands_to_run(
         service=service,
-        remote_dependencies=remote_dependencies,
+        remote_dependencies=list(remote_dependencies),
         current_env=current_env,
         command="down",
         options=[],

--- a/devservices/commands/logs.py
+++ b/devservices/commands/logs.py
@@ -99,7 +99,7 @@ def _logs(
     ] = relative_local_dependency_directory
     docker_compose_commands = get_docker_compose_commands_to_run(
         service=service,
-        remote_dependencies=remote_dependencies,
+        remote_dependencies=list(remote_dependencies),
         current_env=current_env,
         command="logs",
         options=["-n", MAX_LOG_LINES],

--- a/devservices/commands/status.py
+++ b/devservices/commands/status.py
@@ -137,7 +137,7 @@ def _status(
     ] = relative_local_dependency_directory
     docker_compose_commands = get_docker_compose_commands_to_run(
         service=service,
-        remote_dependencies=remote_dependencies,
+        remote_dependencies=list(remote_dependencies),
         current_env=current_env,
         command="ps",
         options=["--format", "json"],

--- a/devservices/utils/dependencies.py
+++ b/devservices/utils/dependencies.py
@@ -5,6 +5,7 @@ import os
 import shutil
 import subprocess
 import tempfile
+from collections import deque
 from concurrent.futures import as_completed
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
@@ -64,13 +65,17 @@ class DependencyGraph:
             for dependency in self.graph[service_name]:
                 in_degree[dependency] += 1
 
-        queue = [
-            service_name for service_name in self.graph if in_degree[service_name] == 0
-        ]
+        queue = deque(
+            [
+                service_name
+                for service_name in self.graph
+                if in_degree[service_name] == 0
+            ]
+        )
         topological_order = list()
 
         while queue:
-            service_name = queue.pop(0)
+            service_name = queue.popleft()
             topological_order.append(service_name)
 
             for dependency in self.graph[service_name]:

--- a/devservices/utils/docker_compose.py
+++ b/devservices/utils/docker_compose.py
@@ -163,7 +163,7 @@ def _get_non_remote_services(
 
 def get_docker_compose_commands_to_run(
     service: Service,
-    remote_dependencies: set[InstalledRemoteDependency],
+    remote_dependencies: list[InstalledRemoteDependency],
     current_env: dict[str, str],
     command: str,
     options: list[str],
@@ -184,18 +184,7 @@ def get_docker_compose_commands_to_run(
         + sorted(list(services_to_use))  # Sort the services to prevent flaky tests
         + options
     )
-    # Sort the remote dependencies by service name to ensure a deterministic order
-    SHARED_DEPENDENCY_NAME_PREFIX = "shared-"
-    # TODO: Remove this sorting key fn, we need to create a dependency graph to accurately start dependencies in order.
-    sorting_key_fn = (
-        lambda dependency: (
-            "0"
-            if dependency.service_name.startswith(SHARED_DEPENDENCY_NAME_PREFIX)
-            else "1"
-        )
-        + dependency.service_name
-    )
-    for dependency in sorted(remote_dependencies, key=sorting_key_fn):
+    for dependency in remote_dependencies:
         # TODO: Consider passing in service config in InstalledRemoteDependency instead of loading it here
         dependency_service_config = load_service_config_from_file(dependency.repo_path)
         dependency_config_path = os.path.join(

--- a/tests/utils/test_dependencies.py
+++ b/tests/utils/test_dependencies.py
@@ -1599,6 +1599,11 @@ def test_construct_dependency_graph_simple(
             },
             "modes": {"default": ["dependency-1"]},
         },
+        "services": {
+            "dependency-1": {
+                "image": "dependency-1",
+            },
+        },
     }
     create_config_file(dependency_service_repo_path, dependency_service_repo_config)
     run_git_command(["add", "."], cwd=dependency_service_repo_path)
@@ -1667,6 +1672,11 @@ def test_construct_dependency_graph_one_nested_dependency(
             },
             "modes": {"default": ["child-service", "parent-service"]},
         },
+        "services": {
+            "parent-service": {
+                "image": "parent-service",
+            },
+        },
     }
     child_service_repo_config = {
         "x-sentry-service-config": {
@@ -1678,6 +1688,11 @@ def test_construct_dependency_graph_one_nested_dependency(
                 },
             },
             "modes": {"default": ["child-service"]},
+        },
+        "services": {
+            "child-service": {
+                "image": "child-service",
+            },
         },
     }
     create_config_file(parent_service_repo_path, parent_service_repo_config)
@@ -1760,6 +1775,11 @@ def test_construct_dependency_graph_shared_dependency(
             },
             "modes": {"default": ["child-service", "parent-service"]},
         },
+        "services": {
+            "parent-service": {
+                "image": "parent-service",
+            },
+        },
     }
     child_service_repo_config = {
         "x-sentry-service-config": {
@@ -1771,6 +1791,11 @@ def test_construct_dependency_graph_shared_dependency(
                 },
             },
             "modes": {"default": ["child-service"]},
+        },
+        "services": {
+            "child-service": {
+                "image": "child-service",
+            },
         },
     }
     create_config_file(parent_service_repo_path, parent_service_repo_config)
@@ -1863,6 +1888,11 @@ def test_construct_dependency_graph_complex(
             },
             "modes": {"default": ["child-service", "parent-service"]},
         },
+        "services": {
+            "parent-service": {
+                "image": "parent-service",
+            },
+        },
     }
     child_service_repo_config = {
         "x-sentry-service-config": {
@@ -1874,6 +1904,11 @@ def test_construct_dependency_graph_complex(
                 },
             },
             "modes": {"default": ["child-service"]},
+        },
+        "services": {
+            "child-service": {
+                "image": "child-service",
+            },
         },
     }
     grandparent_service_repo_config = {
@@ -1894,6 +1929,11 @@ def test_construct_dependency_graph_complex(
                 },
             },
             "modes": {"default": ["parent-service", "grandparent-service"]},
+        },
+        "services": {
+            "grandparent-service": {
+                "image": "grandparent-service",
+            },
         },
     }
     create_config_file(parent_service_repo_path, parent_service_repo_config)

--- a/tests/utils/test_docker_compose.py
+++ b/tests/utils/test_docker_compose.py
@@ -608,7 +608,7 @@ def test_get_all_commands_to_run_complex_shared_dependency(
         service_config_file_path=service_config_file_path,
         mode_dependencies=mode_dependencies,
     )
-    print(commands)
+
     assert commands == [
         [
             "docker",

--- a/tests/utils/test_docker_compose.py
+++ b/tests/utils/test_docker_compose.py
@@ -290,7 +290,7 @@ def test_get_all_commands_to_run_simple_local(
     )
     commands = get_docker_compose_commands_to_run(
         service=service,
-        remote_dependencies=remote_dependencies,
+        remote_dependencies=list(remote_dependencies),
         current_env=current_env,
         command=command,
         options=options,
@@ -343,7 +343,7 @@ def test_get_all_commands_to_run_no_services_to_use(
     )
     commands = get_docker_compose_commands_to_run(
         service=service,
-        remote_dependencies=remote_dependencies,
+        remote_dependencies=list(remote_dependencies),
         current_env=current_env,
         command=command,
         options=options,
@@ -400,7 +400,7 @@ def test_get_all_commands_to_run_simple_remote(
     ]
     commands = get_docker_compose_commands_to_run(
         service=service,
-        remote_dependencies=remote_dependencies,
+        remote_dependencies=list(remote_dependencies),
         current_env=current_env,
         command=command,
         options=options,
@@ -497,7 +497,7 @@ def test_get_all_commands_to_run_complex_remote(
     ]
     commands = get_docker_compose_commands_to_run(
         service=service,
-        remote_dependencies=remote_dependencies,
+        remote_dependencies=list(remote_dependencies),
         current_env=current_env,
         command=command,
         options=options,
@@ -607,7 +607,7 @@ def test_get_all_commands_to_run_complex_shared_dependency(
     ]
     commands = get_docker_compose_commands_to_run(
         service=service,
-        remote_dependencies=remote_dependencies,
+        remote_dependencies=list(remote_dependencies),
         current_env=current_env,
         command=command,
         options=options,

--- a/tests/utils/test_docker_compose.py
+++ b/tests/utils/test_docker_compose.py
@@ -275,7 +275,7 @@ def test_get_all_commands_to_run_simple_local(
     child_service_repo_path_str = str(child_service_repo_path)
 
     service_config = load_service_config_from_file(child_service_repo_path_str)
-    remote_dependencies: set[InstalledRemoteDependency] = set()
+    remote_dependencies: list[InstalledRemoteDependency] = []
     current_env = os.environ.copy()
     command = "up"
     options = ["-d"]
@@ -328,7 +328,7 @@ def test_get_all_commands_to_run_no_services_to_use(
     child_service_repo_path_str = str(child_service_repo_path)
 
     service_config = load_service_config_from_file(child_service_repo_path_str)
-    remote_dependencies: set[InstalledRemoteDependency] = set()
+    remote_dependencies: list[InstalledRemoteDependency] = []
     current_env = os.environ.copy()
     command = "up"
     options = ["-d"]
@@ -343,7 +343,7 @@ def test_get_all_commands_to_run_no_services_to_use(
     )
     commands = get_docker_compose_commands_to_run(
         service=service,
-        remote_dependencies=list(remote_dependencies),
+        remote_dependencies=remote_dependencies,
         current_env=current_env,
         command=command,
         options=options,
@@ -370,15 +370,13 @@ def test_get_all_commands_to_run_simple_remote(
         repo_path=parent_service_repo_path_str,
         config=service_config,
     )
-    remote_dependencies = set(
-        [
-            InstalledRemoteDependency(
-                service_name="child-service",
-                repo_path=child_service_repo_path_str,
-                mode="default",
-            )
-        ]
-    )
+    remote_dependencies = [
+        InstalledRemoteDependency(
+            service_name="child-service",
+            repo_path=child_service_repo_path_str,
+            mode="default",
+        )
+    ]
     current_env = os.environ.copy()
     command = "up"
     options = ["-d"]
@@ -400,7 +398,7 @@ def test_get_all_commands_to_run_simple_remote(
     ]
     commands = get_docker_compose_commands_to_run(
         service=service,
-        remote_dependencies=list(remote_dependencies),
+        remote_dependencies=remote_dependencies,
         current_env=current_env,
         command=command,
         options=options,
@@ -457,20 +455,18 @@ def test_get_all_commands_to_run_complex_remote(
         repo_path=grandparent_service_repo_path_str,
         config=service_config,
     )
-    remote_dependencies = set(
-        [
-            InstalledRemoteDependency(
-                service_name="child-service",
-                repo_path=child_service_repo_path_str,
-                mode="default",
-            ),
-            InstalledRemoteDependency(
-                service_name="parent-service",
-                repo_path=parent_service_repo_path_str,
-                mode="default",
-            ),
-        ]
-    )
+    remote_dependencies = [
+        InstalledRemoteDependency(
+            service_name="child-service",
+            repo_path=child_service_repo_path_str,
+            mode="default",
+        ),
+        InstalledRemoteDependency(
+            service_name="parent-service",
+            repo_path=parent_service_repo_path_str,
+            mode="default",
+        ),
+    ]
     current_env = os.environ.copy()
     command = "up"
     options = ["-d"]
@@ -567,20 +563,18 @@ def test_get_all_commands_to_run_complex_shared_dependency(
         repo_path=grandparent_service_repo_path_str,
         config=service_config,
     )
-    remote_dependencies = set(
-        [
-            InstalledRemoteDependency(
-                service_name="child-service",
-                repo_path=child_service_repo_path_str,
-                mode="default",
-            ),
-            InstalledRemoteDependency(
-                service_name="shared-parent-service",
-                repo_path=parent_service_repo_path_str,
-                mode="default",
-            ),
-        ]
-    )
+    remote_dependencies = [
+        InstalledRemoteDependency(
+            service_name="child-service",
+            repo_path=child_service_repo_path_str,
+            mode="default",
+        ),
+        InstalledRemoteDependency(
+            service_name="shared-parent-service",
+            repo_path=parent_service_repo_path_str,
+            mode="default",
+        ),
+    ]
     current_env = os.environ.copy()
     command = "up"
     options = ["-d"]
@@ -592,12 +586,12 @@ def test_get_all_commands_to_run_complex_shared_dependency(
         subprocess.CompletedProcess(
             args=["docker", "compose", "config", "--services"],
             returncode=0,
-            stdout="parent-service\n",
+            stdout="child-service\n",
         ),
         subprocess.CompletedProcess(
             args=["docker", "compose", "config", "--services"],
             returncode=0,
-            stdout="child-service\n",
+            stdout="parent-service\n",
         ),
         subprocess.CompletedProcess(
             args=["docker", "compose", "config", "--services"],
@@ -607,27 +601,15 @@ def test_get_all_commands_to_run_complex_shared_dependency(
     ]
     commands = get_docker_compose_commands_to_run(
         service=service,
-        remote_dependencies=list(remote_dependencies),
+        remote_dependencies=remote_dependencies,
         current_env=current_env,
         command=command,
         options=options,
         service_config_file_path=service_config_file_path,
         mode_dependencies=mode_dependencies,
     )
+    print(commands)
     assert commands == [
-        [
-            "docker",
-            "compose",
-            "-p",
-            "parent-service",
-            "-f",
-            os.path.join(
-                parent_service_repo_path_str, DEVSERVICES_DIR_NAME, CONFIG_FILE_NAME
-            ),
-            "up",
-            "parent-service",
-            "-d",
-        ],
         [
             "docker",
             "compose",
@@ -639,6 +621,19 @@ def test_get_all_commands_to_run_complex_shared_dependency(
             ),
             "up",
             "child-service",
+            "-d",
+        ],
+        [
+            "docker",
+            "compose",
+            "-p",
+            "parent-service",
+            "-f",
+            os.path.join(
+                parent_service_repo_path_str, DEVSERVICES_DIR_NAME, CONFIG_FILE_NAME
+            ),
+            "up",
+            "parent-service",
             "-d",
         ],
         [


### PR DESCRIPTION
Currently, our logic does not handle bringing up services in the correct order such that dependencies are started before their dependents. This change addresses that by constructing a dependency graph and using reverse topological ordering to determine the ordering in which we should bring services up.