### PR TITLE
feat(services): Adding test for skipping non-devservices repos

### DIFF
--- a/testing/resources/non-devservices-repo/README.md
+++ b/testing/resources/non-devservices-repo/README.md
@@ -1,1 +1,1 @@
-# This is a repo with a devservices config
+# This is a repo without a devservices config

--- a/testing/resources/non-devservices-repo/README.md
+++ b/testing/resources/non-devservices-repo/README.md
@@ -1,0 +1,1 @@
+# This is a repo with a devservices config

--- a/tests/utils/test_services.py
+++ b/tests/utils/test_services.py
@@ -57,3 +57,27 @@ def test_get_local_services_with_valid_config(tmp_path: Path) -> None:
         assert len(local_services) == 1
         assert local_services[0].name == "basic"
         assert local_services[0].repo_path == str(mock_repo_path)
+
+
+def test_get_local_services_skips_non_devservices_repos(tmp_path: Path) -> None:
+    mock_code_root = tmp_path / "code"
+    with (
+        mock.patch(
+            "devservices.utils.dependencies.DEVSERVICES_DEPENDENCIES_CACHE_DIR",
+            str(tmp_path / "dependency-dir"),
+        ),
+        mock.patch(
+            "devservices.utils.services.get_coderoot",
+            return_value=str(mock_code_root),
+        ),
+    ):
+        os.makedirs(mock_code_root)
+        mock_devservices_repo_path = mock_code_root / "basic"
+        mock_non_devservices_repo_path = mock_code_root / "non-devservices"
+        create_mock_git_repo("basic_repo", mock_devservices_repo_path)
+        create_mock_git_repo("non-devservices-repo", mock_non_devservices_repo_path)
+
+        local_services = get_local_services(str(mock_code_root))
+        assert len(local_services) == 1
+        assert local_services[0].name == "basic"
+        assert local_services[0].repo_path == str(mock_devservices_repo_path)

--- a/tests/utils/test_services.py
+++ b/tests/utils/test_services.py
@@ -72,12 +72,12 @@ def test_get_local_services_skips_non_devservices_repos(tmp_path: Path) -> None:
         ),
     ):
         os.makedirs(mock_code_root)
-        mock_devservices_repo_path = mock_code_root / "basic"
+        mock_basic_repo_path = mock_code_root / "basic"
         mock_non_devservices_repo_path = mock_code_root / "non-devservices"
-        create_mock_git_repo("basic_repo", mock_devservices_repo_path)
+        create_mock_git_repo("basic_repo", mock_basic_repo_path)
         create_mock_git_repo("non-devservices-repo", mock_non_devservices_repo_path)
 
         local_services = get_local_services(str(mock_code_root))
         assert len(local_services) == 1
         assert local_services[0].name == "basic"
-        assert local_services[0].repo_path == str(mock_devservices_repo_path)
+        assert local_services[0].repo_path == str(mock_basic_repo_path)


### PR DESCRIPTION
Adding an additional test to cover the case where we skip over local repos when they don't contain a devservices config.