### PR TITLE
fix(sentry): Do not report to sentry if service is not found

### DIFF
--- a/devservices/commands/down.py
+++ b/devservices/commands/down.py
@@ -56,8 +56,11 @@ def down(args: Namespace) -> None:
     service_name = args.service_name
     try:
         service = find_matching_service(service_name)
-    except (ConfigError, ServiceNotFoundError) as e:
+    except ConfigError as e:
         capture_exception(e)
+        console.failure(str(e))
+        exit(1)
+    except ServiceNotFoundError as e:
         console.failure(str(e))
         exit(1)
 

--- a/devservices/commands/list_dependencies.py
+++ b/devservices/commands/list_dependencies.py
@@ -32,8 +32,11 @@ def list_dependencies(args: Namespace) -> None:
 
     try:
         service = find_matching_service(service_name)
-    except (ConfigError, ServiceNotFoundError) as e:
+    except ConfigError as e:
         capture_exception(e)
+        console.failure(str(e))
+        exit(1)
+    except ServiceNotFoundError as e:
         console.failure(str(e))
         exit(1)
 

--- a/devservices/commands/logs.py
+++ b/devservices/commands/logs.py
@@ -46,8 +46,11 @@ def logs(args: Namespace) -> None:
     service_name = args.service_name
     try:
         service = find_matching_service(service_name)
-    except (ConfigError, ServiceNotFoundError) as e:
+    except ConfigError as e:
         capture_exception(e)
+        console.failure(str(e))
+        exit(1)
+    except ServiceNotFoundError as e:
         console.failure(str(e))
         exit(1)
 

--- a/devservices/commands/status.py
+++ b/devservices/commands/status.py
@@ -81,8 +81,11 @@ def status(args: Namespace) -> None:
     service_name = args.service_name
     try:
         service = find_matching_service(service_name)
-    except (ConfigError, ServiceNotFoundError) as e:
+    except ConfigError as e:
         capture_exception(e)
+        console.failure(str(e))
+        exit(1)
+    except ServiceNotFoundError as e:
         console.failure(str(e))
         exit(1)
 

--- a/devservices/commands/up.py
+++ b/devservices/commands/up.py
@@ -58,8 +58,11 @@ def up(args: Namespace) -> None:
     service_name = args.service_name
     try:
         service = find_matching_service(service_name)
-    except (ConfigError, ServiceNotFoundError) as e:
+    except ConfigError as e:
         capture_exception(e)
+        console.failure(str(e))
+        exit(1)
+    except ServiceNotFoundError as e:
         console.failure(str(e))
         exit(1)
 


### PR DESCRIPTION
This adds additional noise, so let's not report to sentry if ServiceNotFound error is raised