### PR TITLE
fix(dependencies): Fixing dependency graph construction for simple modes

### DIFF
--- a/devservices/commands/up.py
+++ b/devservices/commands/up.py
@@ -142,7 +142,7 @@ def up(args: Namespace) -> None:
             pass
         try:
             mode_dependencies = modes[mode]
-            _up(service, remote_dependencies, mode_dependencies, status)
+            _up(service, [mode], remote_dependencies, mode_dependencies, status)
         except DockerComposeError as dce:
             capture_exception(dce)
             status.failure(f"Failed to start {service.name}: {dce.stderr}")
@@ -163,6 +163,7 @@ def _bring_up_dependency(
 
 def _up(
     service: Service,
+    modes: list[str],
     remote_dependencies: set[InstalledRemoteDependency],
     mode_dependencies: list[str],
     status: Status,
@@ -180,7 +181,7 @@ def _up(
         DEVSERVICES_DEPENDENCIES_CACHE_DIR_KEY
     ] = relative_local_dependency_directory
     options = ["-d"]
-    dependency_graph = construct_dependency_graph(service)
+    dependency_graph = construct_dependency_graph(service, modes=modes)
     starting_order = dependency_graph.get_starting_order()
     sorted_remote_dependencies = sorted(
         remote_dependencies, key=lambda dep: starting_order.index(dep.service_name)

--- a/devservices/utils/dependencies.py
+++ b/devservices/utils/dependencies.py
@@ -531,14 +531,14 @@ def construct_dependency_graph(
 ) -> DependencyGraph:
     dependency_graph = DependencyGraph()
 
-    if modes is None:
-        modes = ["default"]
-
-    service_mode_dependencies = set()
-    for mode in modes:
-        service_mode_dependencies.update(service.config.modes.get(mode, []))
-
-    def _construct_dependency_graph(service_config: ServiceConfig) -> None:
+    def _construct_dependency_graph(
+        service_config: ServiceConfig, modes: list[str]
+    ) -> None:
+        if modes is None:
+            modes = ["default"]
+        service_mode_dependencies = set()
+        for mode in modes:
+            service_mode_dependencies.update(service_config.modes.get(mode, []))
         for dependency_name, dependency in service_config.dependencies.items():
             # Skip the dependency if it's not in the modes (since it may not be installed and we don't care about it)
             if (
@@ -549,7 +549,7 @@ def construct_dependency_graph(
             dependency_graph.add_edge(service_config.service_name, dependency_name)
             if _has_remote_config(dependency.remote):
                 dependency_config = get_remote_dependency_config(dependency.remote)
-                _construct_dependency_graph(dependency_config)
+                _construct_dependency_graph(dependency_config, [dependency.remote.mode])
 
-    _construct_dependency_graph(service.config)
+    _construct_dependency_graph(service.config, modes or ["default"])
     return dependency_graph

--- a/devservices/utils/dependencies.py
+++ b/devservices/utils/dependencies.py
@@ -526,9 +526,7 @@ def get_remote_dependency_config(remote_config: RemoteConfig) -> ServiceConfig:
     return load_service_config_from_file(dependency_repo_dir)
 
 
-def construct_dependency_graph(
-    service: Service, modes: list[str] | None = None
-) -> DependencyGraph:
+def construct_dependency_graph(service: Service, modes: list[str]) -> DependencyGraph:
     dependency_graph = DependencyGraph()
 
     def _construct_dependency_graph(
@@ -546,5 +544,5 @@ def construct_dependency_graph(
                 dependency_config = get_remote_dependency_config(dependency.remote)
                 _construct_dependency_graph(dependency_config, [dependency.remote.mode])
 
-    _construct_dependency_graph(service.config, modes or ["default"])
+    _construct_dependency_graph(service.config, modes)
     return dependency_graph

--- a/devservices/utils/dependencies.py
+++ b/devservices/utils/dependencies.py
@@ -541,10 +541,7 @@ def construct_dependency_graph(
             service_mode_dependencies.update(service_config.modes.get(mode, []))
         for dependency_name, dependency in service_config.dependencies.items():
             # Skip the dependency if it's not in the modes (since it may not be installed and we don't care about it)
-            if (
-                service_config.service_name == service.name
-                and dependency_name not in service_mode_dependencies
-            ):
+            if dependency_name not in service_mode_dependencies:
                 continue
             dependency_graph.add_edge(service_config.service_name, dependency_name)
             if _has_remote_config(dependency.remote):

--- a/devservices/utils/dependencies.py
+++ b/devservices/utils/dependencies.py
@@ -534,8 +534,6 @@ def construct_dependency_graph(
     def _construct_dependency_graph(
         service_config: ServiceConfig, modes: list[str]
     ) -> None:
-        if modes is None:
-            modes = ["default"]
         service_mode_dependencies = set()
         for mode in modes:
             service_mode_dependencies.update(service_config.modes.get(mode, []))

--- a/tests/utils/test_dependencies.py
+++ b/tests/utils/test_dependencies.py
@@ -1637,7 +1637,7 @@ def test_construct_dependency_graph_simple(
         str(tmp_path / "dependency-dir"),
     ):
         install_and_verify_dependencies(service)
-        dependency_graph = construct_dependency_graph(service)
+        dependency_graph = construct_dependency_graph(service, ["default"])
         assert dependency_graph.graph == {
             "dependency-1": set(),
             "test-service": {"dependency-1"},
@@ -1735,7 +1735,7 @@ def test_construct_dependency_graph_one_nested_dependency(
         str(tmp_path / "dependency-dir"),
     ):
         install_and_verify_dependencies(service)
-        dependency_graph = construct_dependency_graph(service)
+        dependency_graph = construct_dependency_graph(service, ["default"])
         assert dependency_graph.graph == {
             "child-service": set(),
             "parent-service": {"child-service"},
@@ -1846,7 +1846,7 @@ def test_construct_dependency_graph_shared_dependency(
         str(tmp_path / "dependency-dir"),
     ):
         install_and_verify_dependencies(service)
-        dependency_graph = construct_dependency_graph(service)
+        dependency_graph = construct_dependency_graph(service, ["default"])
         assert dependency_graph.graph == {
             "child-service": set(),
             "parent-service": {"child-service"},
@@ -2043,7 +2043,7 @@ def test_construct_dependency_graph_complex(
         str(tmp_path / "dependency-dir"),
     ):
         install_and_verify_dependencies(service)
-        dependency_graph = construct_dependency_graph(service)
+        dependency_graph = construct_dependency_graph(service, ["default"])
         assert dependency_graph.graph == {
             "child-service": set(),
             "parent-service": {"child-service"},

--- a/tests/utils/test_dependencies.py
+++ b/tests/utils/test_dependencies.py
@@ -1863,12 +1863,31 @@ def test_construct_dependency_graph_shared_dependency(
 def test_construct_dependency_graph_complex(
     tmp_path: Path,
 ) -> None:
+    other_service_repo_path = tmp_path / "other-service-repo"
     parent_service_repo_path = tmp_path / "parent-service-repo"
     child_service_repo_path = tmp_path / "child-service-repo"
     grandparent_service_repo_path = tmp_path / "grandparent-service-repo"
+    create_mock_git_repo("blank_repo", other_service_repo_path)
     create_mock_git_repo("blank_repo", parent_service_repo_path)
     create_mock_git_repo("blank_repo", child_service_repo_path)
     create_mock_git_repo("blank_repo", grandparent_service_repo_path)
+    other_service_repo_config = {
+        "x-sentry-service-config": {
+            "version": 0.1,
+            "service_name": "other-service",
+            "dependencies": {
+                "other-service": {
+                    "description": "other-service",
+                },
+            },
+            "modes": {"default": ["other-service"]},
+        },
+        "services": {
+            "other-service": {
+                "image": "other-service",
+            },
+        },
+    }
     parent_service_repo_config = {
         "x-sentry-service-config": {
             "version": 0.1,
@@ -1885,8 +1904,19 @@ def test_construct_dependency_graph_complex(
                 "parent-service": {
                     "description": "parent-service",
                 },
+                "other-service": {
+                    "description": "other-service",
+                    "remote": {
+                        "repo_name": "other-service",
+                        "repo_link": f"file://{other_service_repo_path}",
+                        "branch": "main",
+                    },
+                },
             },
-            "modes": {"default": ["child-service", "parent-service"]},
+            "modes": {
+                "default": ["child-service", "parent-service"],
+                "other": ["other-service"],
+            },
         },
         "services": {
             "parent-service": {
@@ -1902,8 +1932,16 @@ def test_construct_dependency_graph_complex(
                 "child-service": {
                     "description": "child-service",
                 },
+                "other-service": {
+                    "description": "other-service",
+                    "remote": {
+                        "repo_name": "other-service",
+                        "repo_link": f"file://{other_service_repo_path}",
+                        "branch": "main",
+                    },
+                },
             },
-            "modes": {"default": ["child-service"]},
+            "modes": {"default": ["child-service"], "other": ["other-service"]},
         },
         "services": {
             "child-service": {
@@ -1924,11 +1962,22 @@ def test_construct_dependency_graph_complex(
                         "branch": "main",
                     },
                 },
+                "other-service": {
+                    "description": "other-service",
+                    "remote": {
+                        "repo_name": "other-service",
+                        "repo_link": f"file://{other_service_repo_path}",
+                        "branch": "main",
+                    },
+                },
                 "grandparent-service": {
                     "description": "grandparent-service",
                 },
             },
-            "modes": {"default": ["parent-service", "grandparent-service"]},
+            "modes": {
+                "default": ["parent-service", "grandparent-service"],
+                "other": ["other-service"],
+            },
         },
         "services": {
             "grandparent-service": {
@@ -1936,9 +1985,14 @@ def test_construct_dependency_graph_complex(
             },
         },
     }
+    create_config_file(other_service_repo_path, other_service_repo_config)
     create_config_file(parent_service_repo_path, parent_service_repo_config)
     create_config_file(child_service_repo_path, child_service_repo_config)
     create_config_file(grandparent_service_repo_path, grandparent_service_repo_config)
+    run_git_command(["add", "."], cwd=other_service_repo_path)
+    run_git_command(
+        ["commit", "-m", "Add devservices config"], cwd=other_service_repo_path
+    )
     run_git_command(["add", "."], cwd=parent_service_repo_path)
     run_git_command(
         ["commit", "-m", "Add devservices config"], cwd=parent_service_repo_path


### PR DESCRIPTION
Fixing the dependency graph creation when a mode doesn't contain all of the dependencies and not all dependencies are downloaded. This bug happened because when we made the dependency graph we would traverse all dependencies, even the ones not included in the specified mode, meaning we would potentially traverse some that aren't installed leading to errors. This change addresses that issue by only traversing relevant dependencies for the given mode.