### PR TITLE
feat(purge): Updating purge to only stop relevant containers

### DIFF
--- a/devservices/commands/purge.py
+++ b/devservices/commands/purge.py
@@ -12,7 +12,7 @@ from devservices.constants import DOCKER_NETWORK_NAME
 from devservices.exceptions import DockerDaemonNotRunningError
 from devservices.utils.console import Console
 from devservices.utils.console import Status
-from devservices.utils.docker import stop_all_running_containers
+from devservices.utils.docker import stop_matching_containers
 from devservices.utils.state import State
 
 
@@ -25,14 +25,6 @@ def purge(_args: Namespace) -> None:
     """Purge the local devservices cache."""
     console = Console()
 
-    # Prompt the user to stop all running containers
-    should_stop_containers = console.confirm(
-        "Warning: Purging stops all running containers and clears devservices state. Would you like to continue?"
-    )
-    if not should_stop_containers:
-        console.warning("Purge canceled")
-        return
-
     if os.path.exists(DEVSERVICES_CACHE_DIR):
         try:
             shutil.rmtree(DEVSERVICES_CACHE_DIR)
@@ -42,11 +34,11 @@ def purge(_args: Namespace) -> None:
     state = State()
     state.clear_state()
     with Status(
-        lambda: console.warning("Stopping all running containers"),
-        lambda: console.success("All running containers have been stopped"),
+        lambda: console.warning("Stopping all running devservices containers"),
+        lambda: console.success("All running devservices containers have been stopped"),
     ):
         try:
-            stop_all_running_containers()
+            stop_matching_containers("orchestrator=devservices", should_remove=True)
         except DockerDaemonNotRunningError:
             console.warning("The docker daemon not running, no containers to stop")
 

--- a/devservices/commands/purge.py
+++ b/devservices/commands/purge.py
@@ -8,6 +8,7 @@ from argparse import ArgumentParser
 from argparse import Namespace
 
 from devservices.constants import DEVSERVICES_CACHE_DIR
+from devservices.constants import DEVSERVICES_ORCHESTRATOR_LABEL
 from devservices.constants import DOCKER_NETWORK_NAME
 from devservices.exceptions import DockerDaemonNotRunningError
 from devservices.utils.console import Console
@@ -38,7 +39,7 @@ def purge(_args: Namespace) -> None:
         lambda: console.success("All running devservices containers have been stopped"),
     ):
         try:
-            stop_matching_containers("orchestrator=devservices", should_remove=True)
+            stop_matching_containers(DEVSERVICES_ORCHESTRATOR_LABEL, should_remove=True)
         except DockerDaemonNotRunningError:
             console.warning("The docker daemon not running, no containers to stop")
 

--- a/devservices/commands/purge.py
+++ b/devservices/commands/purge.py
@@ -11,6 +11,7 @@ from devservices.constants import DEVSERVICES_CACHE_DIR
 from devservices.constants import DEVSERVICES_ORCHESTRATOR_LABEL
 from devservices.constants import DOCKER_NETWORK_NAME
 from devservices.exceptions import DockerDaemonNotRunningError
+from devservices.exceptions import DockerError
 from devservices.utils.console import Console
 from devservices.utils.console import Status
 from devservices.utils.docker import stop_matching_containers
@@ -41,7 +42,10 @@ def purge(_args: Namespace) -> None:
         try:
             stop_matching_containers(DEVSERVICES_ORCHESTRATOR_LABEL, should_remove=True)
         except DockerDaemonNotRunningError:
-            console.warning("The docker daemon not running, no containers to stop")
+            console.warning("The docker daemon is not running, no containers to stop")
+        except DockerError as e:
+            console.failure(f"Failed to stop running devservices containers {e.stderr}")
+            exit(1)
 
     console.warning("Removing any devservices networks")
     devservices_networks = (

--- a/devservices/constants.py
+++ b/devservices/constants.py
@@ -11,6 +11,7 @@ DEVSERVICES_CACHE_DIR = os.path.expanduser("~/.cache/sentry-devservices")
 DEVSERVICES_LOCAL_DIR = os.path.expanduser("~/.local/share/sentry-devservices")
 DEVSERVICES_DEPENDENCIES_CACHE_DIR = os.path.join(DEVSERVICES_CACHE_DIR, "dependencies")
 DEVSERVICES_DEPENDENCIES_CACHE_DIR_KEY = "DEVSERVICES_DEPENDENCIES_CACHE_DIR"
+DEVSERVICES_ORCHESTRATOR_LABEL = "orchestrator=devservices"
 STATE_DB_FILE = os.path.join(DEVSERVICES_LOCAL_DIR, "state")
 DOCKER_COMPOSE_COMMAND_LENGTH = 7
 

--- a/devservices/exceptions.py
+++ b/devservices/exceptions.py
@@ -57,14 +57,20 @@ class DockerComposeInstallationError(BinaryInstallError):
     pass
 
 
-class DockerComposeError(Exception):
-    """Base class for Docker Compose related errors."""
+class DockerError(Exception):
+    """Base class for Docker related errors."""
 
     def __init__(self, command: str, returncode: int, stdout: str, stderr: str):
         self.command = command
         self.returncode = returncode
         self.stdout = stdout
         self.stderr = stderr
+
+
+class DockerComposeError(DockerError):
+    """Base class for Docker Compose related errors."""
+
+    pass
 
 
 class ModeDoesNotExistError(Exception):

--- a/devservices/utils/docker.py
+++ b/devservices/utils/docker.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import subprocess
 
 from devservices.exceptions import DockerDaemonNotRunningError
+from devservices.exceptions import DockerError
 
 
 def check_docker_daemon_running() -> None:
@@ -18,19 +19,70 @@ def check_docker_daemon_running() -> None:
         raise DockerDaemonNotRunningError from e
 
 
-def stop_all_running_containers() -> None:
+def get_matching_containers(label: str) -> list[str]:
+    """
+    Returns a list of container IDs with the given label
+    """
     check_docker_daemon_running()
-    running_containers = (
-        subprocess.check_output(["docker", "ps", "-q"], stderr=subprocess.DEVNULL)
-        .decode()
-        .strip()
-        .splitlines()
-    )
-    if len(running_containers) == 0:
+    try:
+        return (
+            subprocess.check_output(
+                [
+                    "docker",
+                    "ps",
+                    "-q",
+                    "--filter",
+                    f"label={label}",
+                ],
+                stderr=subprocess.DEVNULL,
+            )
+            .decode()
+            .strip()
+            .splitlines()
+        )
+    except subprocess.CalledProcessError as e:
+        raise DockerError(
+            command=f"docker ps -q --filter label={label}",
+            returncode=e.returncode,
+            stdout=e.stdout,
+            stderr=e.stderr,
+        ) from e
+
+
+def stop_matching_containers(label: str, should_remove: bool = False) -> None:
+    """
+    Stops all containers with the given label.
+    If should_remove is True, the containers will be removed.
+    """
+    matching_containers = get_matching_containers(label)
+    if len(matching_containers) == 0:
         return
-    subprocess.run(
-        ["docker", "stop"] + running_containers,
-        check=True,
-        stdout=subprocess.DEVNULL,
-        stderr=subprocess.DEVNULL,
-    )
+    try:
+        subprocess.run(
+            ["docker", "stop"] + matching_containers,
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+    except subprocess.CalledProcessError as e:
+        raise DockerError(
+            command=f"docker stop {' '.join(matching_containers)}",
+            returncode=e.returncode,
+            stdout=e.stdout,
+            stderr=e.stderr,
+        ) from e
+    if should_remove:
+        try:
+            subprocess.run(
+                ["docker", "rm"] + matching_containers,
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+        except subprocess.CalledProcessError as e:
+            raise DockerError(
+                command=f"docker rm {' '.join(matching_containers)}",
+                returncode=e.returncode,
+                stdout=e.stdout,
+                stderr=e.stderr,
+            ) from e

--- a/tests/commands/test_purge.py
+++ b/tests/commands/test_purge.py
@@ -4,8 +4,111 @@ from argparse import Namespace
 from pathlib import Path
 from unittest import mock
 
+import pytest
+
 from devservices.commands.purge import purge
+from devservices.exceptions import DockerDaemonNotRunningError
+from devservices.exceptions import DockerError
 from devservices.utils.state import State
+
+
+@mock.patch("devservices.commands.purge.stop_matching_containers")
+@mock.patch("devservices.commands.purge.subprocess.run")
+def test_purge_docker_daemon_not_running(
+    mock_run: mock.Mock,
+    mock_stop_matching_containers: mock.Mock,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    mock_stop_matching_containers.side_effect = DockerDaemonNotRunningError()
+    with (
+        mock.patch(
+            "devservices.commands.purge.DEVSERVICES_CACHE_DIR",
+            str(tmp_path / ".devservices-cache"),
+        ),
+        mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")),
+        mock.patch(
+            "devservices.commands.purge.subprocess.check_output",
+            return_value=b"",
+        ),
+    ):
+        # Create a cache file to test purging
+        cache_dir = tmp_path / ".devservices-cache"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_file = tmp_path / ".devservices-cache" / "test.txt"
+        cache_file.write_text("This is a test cache file.")
+
+        state = State()
+        state.update_started_service("test-service", "test-mode")
+
+        assert cache_file.exists()
+        assert state.get_started_services() == ["test-service"]
+
+        args = Namespace()
+        purge(args)
+
+        assert not cache_file.exists()
+        assert state.get_started_services() == []
+
+        mock_stop_matching_containers.assert_called_once()
+        mock_run.assert_not_called()
+
+        captured = capsys.readouterr()
+        assert (
+            "The docker daemon is not running, no containers to stop"
+            in captured.out.strip()
+        )
+
+
+@mock.patch("devservices.commands.purge.stop_matching_containers")
+@mock.patch("devservices.commands.purge.subprocess.run")
+def test_purge_docker_daemon_docker_error(
+    mock_run: mock.Mock,
+    mock_stop_matching_containers: mock.Mock,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    mock_stop_matching_containers.side_effect = DockerError(
+        "command", 1, "output", "stderr"
+    )
+    with (
+        mock.patch(
+            "devservices.commands.purge.DEVSERVICES_CACHE_DIR",
+            str(tmp_path / ".devservices-cache"),
+        ),
+        mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")),
+        mock.patch(
+            "devservices.commands.purge.subprocess.check_output",
+            return_value=b"",
+        ),
+    ):
+        # Create a cache file to test purging
+        cache_dir = tmp_path / ".devservices-cache"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_file = tmp_path / ".devservices-cache" / "test.txt"
+        cache_file.write_text("This is a test cache file.")
+
+        state = State()
+        state.update_started_service("test-service", "test-mode")
+
+        assert cache_file.exists()
+        assert state.get_started_services() == ["test-service"]
+
+        args = Namespace()
+        with pytest.raises(SystemExit):
+            purge(args)
+
+        assert not cache_file.exists()
+        assert state.get_started_services() == []
+
+        mock_stop_matching_containers.assert_called_once()
+        mock_run.assert_not_called()
+
+        captured = capsys.readouterr()
+        assert (
+            "Failed to stop running devservices containers stderr"
+            in captured.out.strip()
+        )
 
 
 @mock.patch("devservices.commands.purge.stop_matching_containers")

--- a/tests/commands/test_purge.py
+++ b/tests/commands/test_purge.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import builtins
 from argparse import Namespace
 from pathlib import Path
 from unittest import mock
@@ -9,28 +8,10 @@ from devservices.commands.purge import purge
 from devservices.utils.state import State
 
 
-@mock.patch("devservices.commands.purge.stop_all_running_containers")
-def test_purge_not_confirmed(
-    mock_stop_all_running_containers: mock.Mock, tmp_path: Path
-) -> None:
-    with (
-        mock.patch(
-            "devservices.commands.purge.DEVSERVICES_CACHE_DIR",
-            str(tmp_path / ".devservices-cache"),
-        ),
-        mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")),
-        mock.patch.object(builtins, "input", lambda _: "no"),
-    ):
-        args = Namespace()
-        purge(args)
-
-        mock_stop_all_running_containers.assert_not_called()
-
-
-@mock.patch("devservices.commands.purge.stop_all_running_containers")
+@mock.patch("devservices.commands.purge.stop_matching_containers")
 @mock.patch("devservices.commands.purge.subprocess.run")
-def test_purge_with_cache_and_state_and_no_running_containers_confirmed(
-    mock_run: mock.Mock, mock_stop_all_running_containers: mock.Mock, tmp_path: Path
+def test_purge_with_cache_and_state_and_no_running_containers(
+    mock_run: mock.Mock, mock_stop_matching_containers: mock.Mock, tmp_path: Path
 ) -> None:
     with (
         mock.patch(
@@ -38,7 +19,6 @@ def test_purge_with_cache_and_state_and_no_running_containers_confirmed(
             str(tmp_path / ".devservices-cache"),
         ),
         mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")),
-        mock.patch.object(builtins, "input", lambda _: "yes"),
         mock.patch(
             "devservices.utils.docker.check_docker_daemon_running", return_value=None
         ),
@@ -65,14 +45,14 @@ def test_purge_with_cache_and_state_and_no_running_containers_confirmed(
         assert not cache_file.exists()
         assert state.get_started_services() == []
 
-        mock_stop_all_running_containers.assert_called_once()
+        mock_stop_matching_containers.assert_called_once()
         mock_run.assert_not_called()
 
 
-@mock.patch("devservices.commands.purge.stop_all_running_containers")
+@mock.patch("devservices.commands.purge.stop_matching_containers")
 @mock.patch("devservices.commands.purge.subprocess.run")
-def test_purge_with_cache_and_state_and_running_containers_with_networks_confirmed(
-    mock_run: mock.Mock, mock_stop_all_running_containers: mock.Mock, tmp_path: Path
+def test_purge_with_cache_and_state_and_running_containers_with_networks(
+    mock_run: mock.Mock, mock_stop_matching_containers: mock.Mock, tmp_path: Path
 ) -> None:
     with (
         mock.patch(
@@ -80,7 +60,6 @@ def test_purge_with_cache_and_state_and_running_containers_with_networks_confirm
             str(tmp_path / ".devservices-cache"),
         ),
         mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")),
-        mock.patch.object(builtins, "input", lambda _: "yes"),
         mock.patch(
             "devservices.utils.docker.check_docker_daemon_running", return_value=None
         ),
@@ -107,6 +86,7 @@ def test_purge_with_cache_and_state_and_running_containers_with_networks_confirm
         assert not cache_file.exists()
         assert state.get_started_services() == []
 
+        mock_stop_matching_containers.assert_called_once()
         mock_run.assert_has_calls(
             [
                 mock.call(
@@ -129,39 +109,3 @@ def test_purge_with_cache_and_state_and_running_containers_with_networks_confirm
                 ),
             ]
         )
-        mock_stop_all_running_containers.assert_called_once()
-
-
-@mock.patch("devservices.commands.purge.stop_all_running_containers")
-@mock.patch("devservices.commands.purge.subprocess.run")
-def test_purge_with_cache_and_state_and_running_containers_not_confirmed(
-    mock_run: mock.Mock, mock_stop_all_running_containers: mock.Mock, tmp_path: Path
-) -> None:
-    with (
-        mock.patch(
-            "devservices.commands.purge.DEVSERVICES_CACHE_DIR",
-            str(tmp_path / ".devservices-cache"),
-        ),
-        mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")),
-        mock.patch.object(builtins, "input", lambda _: "no"),
-        mock.patch(
-            "devservices.utils.docker.check_docker_daemon_running", return_value=None
-        ),
-    ):
-        # Create a cache file to test purging
-        cache_dir = tmp_path / ".devservices-cache"
-        cache_dir.mkdir(parents=True, exist_ok=True)
-        cache_file = tmp_path / ".devservices-cache" / "test.txt"
-        cache_file.write_text("This is a test cache file.")
-
-        state = State()
-        state.update_started_service("test-service", "test-mode")
-
-        args = Namespace()
-        purge(args)
-
-        assert cache_file.exists()
-        assert state.get_started_services() == ["test-service"]
-
-        mock_run.assert_not_called()
-        mock_stop_all_running_containers.assert_not_called()

--- a/tests/utils/test_docker.py
+++ b/tests/utils/test_docker.py
@@ -3,45 +3,122 @@ from __future__ import annotations
 import subprocess
 from unittest import mock
 
-from devservices.utils.docker import stop_all_running_containers
+import pytest
+
+from devservices.exceptions import DockerDaemonNotRunningError
+from devservices.exceptions import DockerError
+from devservices.utils.docker import check_docker_daemon_running
+from devservices.utils.docker import get_matching_containers
+from devservices.utils.docker import stop_matching_containers
+
+
+@mock.patch("subprocess.run")
+def test_check_docker_daemon_running_error(mock_run: mock.Mock) -> None:
+    mock_run.side_effect = subprocess.CalledProcessError(1, "cmd")
+    with pytest.raises(DockerDaemonNotRunningError):
+        check_docker_daemon_running()
+    mock_run.assert_called_once_with(
+        ["docker", "info"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+
+@mock.patch("subprocess.run")
+def test_check_docker_daemon_running(mock_run: mock.Mock) -> None:
+    check_docker_daemon_running()
+    mock_run.assert_called_once_with(
+        ["docker", "info"],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
 
 
 @mock.patch("subprocess.check_output")
-@mock.patch("subprocess.run")
 @mock.patch("devservices.utils.docker.check_docker_daemon_running")
-def test_stop_all_running_containers_none_running(
+def test_get_matching_containers(
     mock_check_docker_daemon_running: mock.Mock,
-    mock_run: mock.Mock,
     mock_check_output: mock.Mock,
 ) -> None:
     mock_check_docker_daemon_running.return_value = None
     mock_check_output.return_value = b""
-    stop_all_running_containers()
+    get_matching_containers("orchestrator=devservices")
     mock_check_docker_daemon_running.assert_called_once()
     mock_check_output.assert_called_once_with(
-        ["docker", "ps", "-q"], stderr=subprocess.DEVNULL
+        ["docker", "ps", "-q", "--filter", "label=orchestrator=devservices"],
+        stderr=subprocess.DEVNULL,
     )
-    mock_run.assert_not_called()
 
 
 @mock.patch("subprocess.check_output")
-@mock.patch("subprocess.run")
 @mock.patch("devservices.utils.docker.check_docker_daemon_running")
-def test_stop_all_running_containers(
+def test_get_matching_containers_docker_daemon_not_running(
     mock_check_docker_daemon_running: mock.Mock,
-    mock_run: mock.Mock,
+    mock_check_output: mock.Mock,
+) -> None:
+    mock_check_docker_daemon_running.side_effect = DockerDaemonNotRunningError()
+    with pytest.raises(DockerDaemonNotRunningError):
+        get_matching_containers("orchestrator=devservices")
+    mock_check_docker_daemon_running.assert_called_once()
+    mock_check_output.assert_not_called()
+
+
+@mock.patch("subprocess.check_output")
+@mock.patch("devservices.utils.docker.check_docker_daemon_running")
+def test_get_matching_containers_error(
+    mock_check_docker_daemon_running: mock.Mock,
     mock_check_output: mock.Mock,
 ) -> None:
     mock_check_docker_daemon_running.return_value = None
-    mock_check_output.return_value = b"container1\ncontainer2\n"
-    stop_all_running_containers()
+    mock_check_output.side_effect = subprocess.CalledProcessError(1, "cmd")
+    with pytest.raises(DockerError):
+        get_matching_containers("orchestrator=devservices")
     mock_check_docker_daemon_running.assert_called_once()
     mock_check_output.assert_called_once_with(
-        ["docker", "ps", "-q"], stderr=subprocess.DEVNULL
+        ["docker", "ps", "-q", "--filter", "label=orchestrator=devservices"],
+        stderr=subprocess.DEVNULL,
     )
+
+
+@mock.patch("subprocess.run")
+@mock.patch("devservices.utils.docker.get_matching_containers")
+def test_stop_matching_containers_should_not_remove(
+    mock_get_matching_containers: mock.Mock,
+    mock_run: mock.Mock,
+) -> None:
+    mock_get_matching_containers.return_value = ["container1", "container2"]
+    stop_matching_containers("orchestrator=devservices", should_remove=False)
     mock_run.assert_called_once_with(
         ["docker", "stop", "container1", "container2"],
         check=True,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
+    )
+
+
+@mock.patch("subprocess.run")
+@mock.patch("devservices.utils.docker.get_matching_containers")
+def test_stop_matching_containers_should_remove(
+    mock_get_matching_containers: mock.Mock,
+    mock_run: mock.Mock,
+) -> None:
+    mock_get_matching_containers.return_value = ["container1", "container2"]
+    stop_matching_containers("orchestrator=devservices", should_remove=True)
+    mock_run.assert_has_calls(
+        [
+            mock.call(
+                ["docker", "stop", "container1", "container2"],
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            ),
+            mock.call(
+                ["docker", "rm", "container1", "container2"],
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            ),
+        ]
     )

--- a/tests/utils/test_docker.py
+++ b/tests/utils/test_docker.py
@@ -5,6 +5,7 @@ from unittest import mock
 
 import pytest
 
+from devservices.constants import DEVSERVICES_ORCHESTRATOR_LABEL
 from devservices.exceptions import DockerDaemonNotRunningError
 from devservices.exceptions import DockerError
 from devservices.utils.docker import check_docker_daemon_running
@@ -44,10 +45,10 @@ def test_get_matching_containers(
 ) -> None:
     mock_check_docker_daemon_running.return_value = None
     mock_check_output.return_value = b""
-    get_matching_containers("orchestrator=devservices")
+    get_matching_containers(DEVSERVICES_ORCHESTRATOR_LABEL)
     mock_check_docker_daemon_running.assert_called_once()
     mock_check_output.assert_called_once_with(
-        ["docker", "ps", "-q", "--filter", "label=orchestrator=devservices"],
+        ["docker", "ps", "-q", "--filter", f"label={DEVSERVICES_ORCHESTRATOR_LABEL}"],
         stderr=subprocess.DEVNULL,
     )
 
@@ -60,7 +61,7 @@ def test_get_matching_containers_docker_daemon_not_running(
 ) -> None:
     mock_check_docker_daemon_running.side_effect = DockerDaemonNotRunningError()
     with pytest.raises(DockerDaemonNotRunningError):
-        get_matching_containers("orchestrator=devservices")
+        get_matching_containers(DEVSERVICES_ORCHESTRATOR_LABEL)
     mock_check_docker_daemon_running.assert_called_once()
     mock_check_output.assert_not_called()
 
@@ -74,10 +75,10 @@ def test_get_matching_containers_error(
     mock_check_docker_daemon_running.return_value = None
     mock_check_output.side_effect = subprocess.CalledProcessError(1, "cmd")
     with pytest.raises(DockerError):
-        get_matching_containers("orchestrator=devservices")
+        get_matching_containers(DEVSERVICES_ORCHESTRATOR_LABEL)
     mock_check_docker_daemon_running.assert_called_once()
     mock_check_output.assert_called_once_with(
-        ["docker", "ps", "-q", "--filter", "label=orchestrator=devservices"],
+        ["docker", "ps", "-q", "--filter", f"label={DEVSERVICES_ORCHESTRATOR_LABEL}"],
         stderr=subprocess.DEVNULL,
     )
 
@@ -89,7 +90,7 @@ def test_stop_matching_containers_should_not_remove(
     mock_run: mock.Mock,
 ) -> None:
     mock_get_matching_containers.return_value = ["container1", "container2"]
-    stop_matching_containers("orchestrator=devservices", should_remove=False)
+    stop_matching_containers(DEVSERVICES_ORCHESTRATOR_LABEL, should_remove=False)
     mock_run.assert_called_once_with(
         ["docker", "stop", "container1", "container2"],
         check=True,
@@ -105,7 +106,7 @@ def test_stop_matching_containers_should_remove(
     mock_run: mock.Mock,
 ) -> None:
     mock_get_matching_containers.return_value = ["container1", "container2"]
-    stop_matching_containers("orchestrator=devservices", should_remove=True)
+    stop_matching_containers(DEVSERVICES_ORCHESTRATOR_LABEL, should_remove=True)
     mock_run.assert_has_calls(
         [
             mock.call(

--- a/tests/utils/test_docker.py
+++ b/tests/utils/test_docker.py
@@ -101,6 +101,17 @@ def test_stop_matching_containers_should_not_remove(
 
 @mock.patch("subprocess.run")
 @mock.patch("devservices.utils.docker.get_matching_containers")
+def test_stop_matching_containers_none(
+    mock_get_matching_containers: mock.Mock,
+    mock_run: mock.Mock,
+) -> None:
+    mock_get_matching_containers.return_value = []
+    stop_matching_containers(DEVSERVICES_ORCHESTRATOR_LABEL, should_remove=True)
+    mock_run.assert_not_called()
+
+
+@mock.patch("subprocess.run")
+@mock.patch("devservices.utils.docker.get_matching_containers")
 def test_stop_matching_containers_should_remove(
     mock_get_matching_containers: mock.Mock,
     mock_run: mock.Mock,


### PR DESCRIPTION
Updating purge to stop relevant containers and remove them rather than stopping all containers. This makes use of the newly added labels we added to the configs of the various services.