### PR TITLE
feat(purge): Purge removes corresponding volumes

### DIFF
--- a/devservices/commands/purge.py
+++ b/devservices/commands/purge.py
@@ -56,8 +56,6 @@ def purge(_args: Namespace) -> None:
     ):
         try:
             stop_containers(devservices_containers, should_remove=True)
-        except DockerDaemonNotRunningError:
-            console.warning("The docker daemon is not running, no containers to stop")
         except DockerError as e:
             console.failure(f"Failed to stop running devservices containers {e.stderr}")
             exit(1)

--- a/devservices/commands/purge.py
+++ b/devservices/commands/purge.py
@@ -64,13 +64,17 @@ def purge(_args: Namespace) -> None:
     if len(devservices_volumes) == 0:
         console.success("No devservices volumes found to remove")
     else:
-        subprocess.run(
-            ["docker", "volume", "rm", *devservices_volumes],
-            check=True,
-            stdout=subprocess.DEVNULL,
-            stderr=subprocess.DEVNULL,
-        )
-        console.success("All devservices volumes removed")
+        try:
+            subprocess.run(
+                ["docker", "volume", "rm", *devservices_volumes],
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
+            console.success("All devservices volumes removed")
+        except subprocess.CalledProcessError as e:
+            # We don't want to exit here since we still want to try to remove the networks
+            console.failure(f"Failed to remove devservices volumes {e.stderr}")
 
     console.warning("Removing any devservices networks")
     devservices_networks = (

--- a/devservices/commands/purge.py
+++ b/devservices/commands/purge.py
@@ -83,9 +83,10 @@ def purge(_args: Namespace) -> None:
                 f"name={DOCKER_NETWORK_NAME}",
                 "--format",
                 "{{.ID}}",
-            ]
+            ],
+            text=True,
+            stderr=subprocess.DEVNULL,
         )
-        .decode()
         .strip()
         .splitlines()
     )

--- a/devservices/commands/purge.py
+++ b/devservices/commands/purge.py
@@ -39,13 +39,16 @@ def purge(_args: Namespace) -> None:
     state.clear_state()
     try:
         devservices_containers = get_matching_containers(DEVSERVICES_ORCHESTRATOR_LABEL)
-    except DockerError as e:
-        console.failure(f"Failed to get devservices containers {e}")
+    except DockerDaemonNotRunningError as e:
+        console.warning(str(e))
+        return
+    except DockerError as de:
+        console.failure(f"Failed to get devservices containers {de.stderr}")
         exit(1)
     try:
         devservices_volumes = get_volumes_for_containers(devservices_containers)
     except DockerError as e:
-        console.failure(f"Failed to get devservices volumes {e}")
+        console.failure(f"Failed to get devservices volumes {e.stderr}")
         exit(1)
     with Status(
         lambda: console.warning("Stopping all running devservices containers"),

--- a/devservices/commands/purge.py
+++ b/devservices/commands/purge.py
@@ -14,7 +14,9 @@ from devservices.exceptions import DockerDaemonNotRunningError
 from devservices.exceptions import DockerError
 from devservices.utils.console import Console
 from devservices.utils.console import Status
-from devservices.utils.docker import stop_matching_containers
+from devservices.utils.docker import get_matching_containers
+from devservices.utils.docker import get_volumes_for_containers
+from devservices.utils.docker import stop_containers
 from devservices.utils.state import State
 
 
@@ -35,17 +37,39 @@ def purge(_args: Namespace) -> None:
             exit(1)
     state = State()
     state.clear_state()
+    try:
+        devservices_containers = get_matching_containers(DEVSERVICES_ORCHESTRATOR_LABEL)
+    except DockerError as e:
+        console.failure(f"Failed to get devservices containers {e}")
+        exit(1)
+    try:
+        devservices_volumes = get_volumes_for_containers(devservices_containers)
+    except DockerError as e:
+        console.failure(f"Failed to get devservices volumes {e}")
+        exit(1)
     with Status(
         lambda: console.warning("Stopping all running devservices containers"),
         lambda: console.success("All running devservices containers have been stopped"),
     ):
         try:
-            stop_matching_containers(DEVSERVICES_ORCHESTRATOR_LABEL, should_remove=True)
+            stop_containers(devservices_containers, should_remove=True)
         except DockerDaemonNotRunningError:
             console.warning("The docker daemon is not running, no containers to stop")
         except DockerError as e:
             console.failure(f"Failed to stop running devservices containers {e.stderr}")
             exit(1)
+
+    console.warning("Removing any devservices docker volumes")
+    if len(devservices_volumes) == 0:
+        console.success("No devservices volumes found to remove")
+    else:
+        subprocess.run(
+            ["docker", "volume", "rm", *devservices_volumes],
+            check=True,
+            stdout=subprocess.DEVNULL,
+            stderr=subprocess.DEVNULL,
+        )
+        console.success("All devservices volumes removed")
 
     console.warning("Removing any devservices networks")
     devservices_networks = (

--- a/tests/commands/test_purge.py
+++ b/tests/commands/test_purge.py
@@ -7,20 +7,23 @@ from unittest import mock
 import pytest
 
 from devservices.commands.purge import purge
+from devservices.constants import DEVSERVICES_ORCHESTRATOR_LABEL
 from devservices.exceptions import DockerDaemonNotRunningError
 from devservices.exceptions import DockerError
 from devservices.utils.state import State
 
 
-@mock.patch("devservices.commands.purge.stop_matching_containers")
+@mock.patch("devservices.commands.purge.get_matching_containers")
+@mock.patch("devservices.commands.purge.stop_containers")
 @mock.patch("devservices.commands.purge.subprocess.run")
 def test_purge_docker_daemon_not_running(
     mock_run: mock.Mock,
-    mock_stop_matching_containers: mock.Mock,
+    mock_stop_containers: mock.Mock,
+    mock_get_matching_containers: mock.Mock,
     capsys: pytest.CaptureFixture[str],
     tmp_path: Path,
 ) -> None:
-    mock_stop_matching_containers.side_effect = DockerDaemonNotRunningError()
+    mock_get_matching_containers.side_effect = DockerDaemonNotRunningError()
     with (
         mock.patch(
             "devservices.commands.purge.DEVSERVICES_CACHE_DIR",
@@ -50,25 +53,30 @@ def test_purge_docker_daemon_not_running(
         assert not cache_file.exists()
         assert state.get_started_services() == []
 
-        mock_stop_matching_containers.assert_called_once()
+        mock_get_matching_containers.assert_called_once_with(
+            DEVSERVICES_ORCHESTRATOR_LABEL
+        )
+        mock_stop_containers.assert_not_called()
         mock_run.assert_not_called()
 
         captured = capsys.readouterr()
         assert (
-            "The docker daemon is not running, no containers to stop"
+            "Unable to connect to the docker daemon. Is the docker daemon running?"
             in captured.out.strip()
         )
 
 
-@mock.patch("devservices.commands.purge.stop_matching_containers")
+@mock.patch("devservices.commands.purge.get_matching_containers")
+@mock.patch("devservices.commands.purge.stop_containers")
 @mock.patch("devservices.commands.purge.subprocess.run")
 def test_purge_docker_daemon_docker_error(
     mock_run: mock.Mock,
-    mock_stop_matching_containers: mock.Mock,
+    mock_stop_containers: mock.Mock,
+    mock_get_matching_containers: mock.Mock,
     capsys: pytest.CaptureFixture[str],
     tmp_path: Path,
 ) -> None:
-    mock_stop_matching_containers.side_effect = DockerError(
+    mock_get_matching_containers.side_effect = DockerError(
         "command", 1, "output", "stderr"
     )
     with (
@@ -101,20 +109,20 @@ def test_purge_docker_daemon_docker_error(
         assert not cache_file.exists()
         assert state.get_started_services() == []
 
-        mock_stop_matching_containers.assert_called_once()
+        mock_get_matching_containers.assert_called_once_with(
+            DEVSERVICES_ORCHESTRATOR_LABEL
+        )
+        mock_stop_containers.assert_not_called()
         mock_run.assert_not_called()
 
         captured = capsys.readouterr()
-        assert (
-            "Failed to stop running devservices containers stderr"
-            in captured.out.strip()
-        )
+        assert "Failed to get devservices containers stderr" in captured.out.strip()
 
 
-@mock.patch("devservices.commands.purge.stop_matching_containers")
+@mock.patch("devservices.commands.purge.stop_containers")
 @mock.patch("devservices.commands.purge.subprocess.run")
 def test_purge_with_cache_and_state_and_no_running_containers(
-    mock_run: mock.Mock, mock_stop_matching_containers: mock.Mock, tmp_path: Path
+    mock_run: mock.Mock, mock_stop_containers: mock.Mock, tmp_path: Path
 ) -> None:
     with (
         mock.patch(
@@ -148,14 +156,14 @@ def test_purge_with_cache_and_state_and_no_running_containers(
         assert not cache_file.exists()
         assert state.get_started_services() == []
 
-        mock_stop_matching_containers.assert_called_once()
+        mock_stop_containers.assert_called_once_with([], should_remove=True)
         mock_run.assert_not_called()
 
 
-@mock.patch("devservices.commands.purge.stop_matching_containers")
+@mock.patch("devservices.commands.purge.stop_containers")
 @mock.patch("devservices.commands.purge.subprocess.run")
 def test_purge_with_cache_and_state_and_running_containers_with_networks(
-    mock_run: mock.Mock, mock_stop_matching_containers: mock.Mock, tmp_path: Path
+    mock_run: mock.Mock, mock_stop_containers: mock.Mock, tmp_path: Path
 ) -> None:
     with (
         mock.patch(
@@ -189,7 +197,9 @@ def test_purge_with_cache_and_state_and_running_containers_with_networks(
         assert not cache_file.exists()
         assert state.get_started_services() == []
 
-        mock_stop_matching_containers.assert_called_once()
+        mock_stop_containers.assert_called_once_with(
+            ["abc", "def", "ghe"], should_remove=True
+        )
         mock_run.assert_has_calls(
             [
                 mock.call(

--- a/tests/commands/test_purge.py
+++ b/tests/commands/test_purge.py
@@ -69,7 +69,7 @@ def test_purge_docker_daemon_not_running(
 @mock.patch("devservices.commands.purge.get_matching_containers")
 @mock.patch("devservices.commands.purge.stop_containers")
 @mock.patch("devservices.commands.purge.subprocess.run")
-def test_purge_docker_daemon_docker_error(
+def test_purge_docker_error_find_matching_containers(
     mock_run: mock.Mock,
     mock_stop_containers: mock.Mock,
     mock_get_matching_containers: mock.Mock,
@@ -117,6 +117,63 @@ def test_purge_docker_daemon_docker_error(
 
         captured = capsys.readouterr()
         assert "Failed to get devservices containers stderr" in captured.out.strip()
+
+
+@mock.patch("devservices.commands.purge.get_matching_containers")
+@mock.patch("devservices.commands.purge.stop_containers")
+@mock.patch("devservices.commands.purge.subprocess.run")
+def test_purge_docker_error_stop_containers(
+    mock_run: mock.Mock,
+    mock_stop_containers: mock.Mock,
+    mock_get_matching_containers: mock.Mock,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    mock_get_matching_containers.return_value = ["abc", "def", "ghi"]
+    mock_stop_containers.side_effect = DockerError("command", 1, "output", "stderr")
+    with (
+        mock.patch(
+            "devservices.commands.purge.DEVSERVICES_CACHE_DIR",
+            str(tmp_path / ".devservices-cache"),
+        ),
+        mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")),
+        mock.patch(
+            "devservices.commands.purge.subprocess.check_output",
+            return_value=b"",
+        ),
+    ):
+        # Create a cache file to test purging
+        cache_dir = tmp_path / ".devservices-cache"
+        cache_dir.mkdir(parents=True, exist_ok=True)
+        cache_file = tmp_path / ".devservices-cache" / "test.txt"
+        cache_file.write_text("This is a test cache file.")
+
+        state = State()
+        state.update_started_service("test-service", "test-mode")
+
+        assert cache_file.exists()
+        assert state.get_started_services() == ["test-service"]
+
+        args = Namespace()
+        with pytest.raises(SystemExit):
+            purge(args)
+
+        assert not cache_file.exists()
+        assert state.get_started_services() == []
+
+        mock_get_matching_containers.assert_called_once_with(
+            DEVSERVICES_ORCHESTRATOR_LABEL
+        )
+        mock_stop_containers.assert_called_once_with(
+            ["abc", "def", "ghi"], should_remove=True
+        )
+        mock_run.assert_not_called()
+
+        captured = capsys.readouterr()
+        assert (
+            "Failed to stop running devservices containers stderr"
+            in captured.out.strip()
+        )
 
 
 @mock.patch("devservices.commands.purge.stop_containers")

--- a/tests/utils/test_docker.py
+++ b/tests/utils/test_docker.py
@@ -10,7 +10,8 @@ from devservices.exceptions import DockerDaemonNotRunningError
 from devservices.exceptions import DockerError
 from devservices.utils.docker import check_docker_daemon_running
 from devservices.utils.docker import get_matching_containers
-from devservices.utils.docker import stop_matching_containers
+from devservices.utils.docker import get_volumes_for_containers
+from devservices.utils.docker import stop_containers
 
 
 @mock.patch("subprocess.run")
@@ -83,16 +84,62 @@ def test_get_matching_containers_error(
     )
 
 
+@mock.patch("subprocess.check_output")
+def test_get_volumes_for_containers_empty(mock_check_output: mock.Mock) -> None:
+    assert get_volumes_for_containers([]) == set()
+    mock_check_output.assert_not_called()
+
+
+@mock.patch("subprocess.check_output")
+def test_get_volumes_for_containers(
+    mock_check_output: mock.Mock,
+) -> None:
+    mock_check_output.return_value = b"volume1\nvolume2"
+    assert get_volumes_for_containers(["container1", "container2"]) == {
+        "volume1",
+        "volume2",
+    }
+    mock_check_output.assert_called_once_with(
+        [
+            "docker",
+            "inspect",
+            "--format",
+            "{{ range .Mounts }}{{ .Name }}\n{{ end }}",
+            "container1",
+            "container2",
+        ],
+        stderr=mock.ANY,
+    )
+
+
+@mock.patch("subprocess.check_output")
+def test_get_volumes_for_containers_error(
+    mock_check_output: mock.Mock,
+) -> None:
+    mock_check_output.side_effect = subprocess.CalledProcessError(1, "cmd")
+    with pytest.raises(DockerError):
+        get_volumes_for_containers(["container1", "container2"])
+    mock_check_output.assert_called_once_with(
+        [
+            "docker",
+            "inspect",
+            "--format",
+            "{{ range .Mounts }}{{ .Name }}\n{{ end }}",
+            "container1",
+            "container2",
+        ],
+        stderr=mock.ANY,
+    )
+
+
 @mock.patch("subprocess.run")
-@mock.patch("devservices.utils.docker.get_matching_containers")
-def test_stop_matching_containers_should_not_remove(
-    mock_get_matching_containers: mock.Mock,
+def test_stop_containers_should_not_remove(
     mock_run: mock.Mock,
 ) -> None:
-    mock_get_matching_containers.return_value = ["container1", "container2"]
-    stop_matching_containers(DEVSERVICES_ORCHESTRATOR_LABEL, should_remove=False)
+    containers = ["container1", "container2"]
+    stop_containers(containers, should_remove=False)
     mock_run.assert_called_once_with(
-        ["docker", "stop", "container1", "container2"],
+        ["docker", "stop", *containers],
         check=True,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
@@ -100,34 +147,29 @@ def test_stop_matching_containers_should_not_remove(
 
 
 @mock.patch("subprocess.run")
-@mock.patch("devservices.utils.docker.get_matching_containers")
-def test_stop_matching_containers_none(
-    mock_get_matching_containers: mock.Mock,
+def test_stop_containers_none(
     mock_run: mock.Mock,
 ) -> None:
-    mock_get_matching_containers.return_value = []
-    stop_matching_containers(DEVSERVICES_ORCHESTRATOR_LABEL, should_remove=True)
+    stop_containers([], should_remove=True)
     mock_run.assert_not_called()
 
 
 @mock.patch("subprocess.run")
-@mock.patch("devservices.utils.docker.get_matching_containers")
-def test_stop_matching_containers_should_remove(
-    mock_get_matching_containers: mock.Mock,
+def test_stop_containers_should_remove(
     mock_run: mock.Mock,
 ) -> None:
-    mock_get_matching_containers.return_value = ["container1", "container2"]
-    stop_matching_containers(DEVSERVICES_ORCHESTRATOR_LABEL, should_remove=True)
+    containers = ["container1", "container2"]
+    stop_containers(containers, should_remove=True)
     mock_run.assert_has_calls(
         [
             mock.call(
-                ["docker", "stop", "container1", "container2"],
+                ["docker", "stop", *containers],
                 check=True,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
             ),
             mock.call(
-                ["docker", "rm", "container1", "container2"],
+                ["docker", "rm", *containers],
                 check=True,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
@@ -137,17 +179,15 @@ def test_stop_matching_containers_should_remove(
 
 
 @mock.patch("subprocess.run")
-@mock.patch("devservices.utils.docker.get_matching_containers")
-def test_stop_matching_containers_stop_error(
-    mock_get_matching_containers: mock.Mock,
+def test_stop_containers_stop_error(
     mock_run: mock.Mock,
 ) -> None:
     mock_run.side_effect = subprocess.CalledProcessError(1, "cmd")
-    mock_get_matching_containers.return_value = ["container1", "container2"]
+    containers = ["container1", "container2"]
     with pytest.raises(DockerError):
-        stop_matching_containers(DEVSERVICES_ORCHESTRATOR_LABEL, should_remove=True)
+        stop_containers(containers, should_remove=True)
     mock_run.assert_called_once_with(
-        ["docker", "stop", "container1", "container2"],
+        ["docker", "stop", *containers],
         check=True,
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
@@ -155,25 +195,23 @@ def test_stop_matching_containers_stop_error(
 
 
 @mock.patch("subprocess.run")
-@mock.patch("devservices.utils.docker.get_matching_containers")
-def test_stop_matching_containers_remove_error(
-    mock_get_matching_containers: mock.Mock,
+def test_stop_containers_remove_error(
     mock_run: mock.Mock,
 ) -> None:
     mock_run.side_effect = [None, subprocess.CalledProcessError(1, "cmd")]
-    mock_get_matching_containers.return_value = ["container1", "container2"]
+    containers = ["container1", "container2"]
     with pytest.raises(DockerError):
-        stop_matching_containers(DEVSERVICES_ORCHESTRATOR_LABEL, should_remove=True)
+        stop_containers(containers, should_remove=True)
     mock_run.assert_has_calls(
         [
             mock.call(
-                ["docker", "stop", "container1", "container2"],
+                ["docker", "stop", *containers],
                 check=True,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,
             ),
             mock.call(
-                ["docker", "rm", "container1", "container2"],
+                ["docker", "rm", *containers],
                 check=True,
                 stdout=subprocess.DEVNULL,
                 stderr=subprocess.DEVNULL,


### PR DESCRIPTION
Adding functionality to remove volumes used by active devservices containers during the purge command. This aims to make purge more effective at clearing all state. One edge case that will still exist that this logic doesn't account for is clearing volumes for containers that are no longer up.