### PR TITLE
fix(up): Always pull new images

### DIFF
--- a/devservices/commands/up.py
+++ b/devservices/commands/up.py
@@ -128,7 +128,7 @@ def _up(
     current_env[
         DEVSERVICES_DEPENDENCIES_CACHE_DIR_KEY
     ] = relative_local_dependency_directory
-    options = ["-d"]
+    options = ["-d", "--pull", "always"]
     dependency_graph = construct_dependency_graph(service, modes=modes)
     starting_order = dependency_graph.get_starting_order()
     sorted_remote_dependencies = sorted(

--- a/tests/commands/test_up.py
+++ b/tests/commands/test_up.py
@@ -90,6 +90,8 @@ def test_up_simple(
                 "clickhouse",
                 "redis",
                 "-d",
+                "--pull",
+                "always",
             ],
             check=True,
             capture_output=True,
@@ -155,6 +157,8 @@ def test_up_dependency_error(
 
         mock_update_started_service.assert_not_called()
 
+        mock_run.assert_not_called()
+
         captured = capsys.readouterr()
         assert "Retrieving dependencies" not in captured.out.strip()
         assert (
@@ -213,6 +217,22 @@ def test_up_error(
     )
 
     mock_update_started_service.assert_not_called()
+
+    mock_run.assert_called_with(
+        [
+            "docker",
+            "compose",
+            "-f",
+            f"{tmp_path}/{DEVSERVICES_DIR_NAME}/{CONFIG_FILE_NAME}",
+            "config",
+            "--services",
+        ],
+        stdout=subprocess.PIPE,
+        timeout=None,
+        check=True,
+        text=True,
+        env=mock.ANY,
+    )
 
     captured = capsys.readouterr()
     assert "Retrieving dependencies" not in captured.out.strip()
@@ -288,6 +308,8 @@ def test_up_mode_simple(
                 "up",
                 "redis",
                 "-d",
+                "--pull",
+                "always",
             ],
             check=True,
             capture_output=True,
@@ -358,6 +380,8 @@ def test_up_mode_does_not_exist(
 
         mock_update_started_service.assert_not_called()
 
+        mock_run.assert_not_called()
+
         captured = capsys.readouterr()
         assert "Retrieving dependencies" not in captured.out.strip()
         assert "Starting 'example-service' in mode: 'test'" not in captured.out.strip()
@@ -426,6 +450,8 @@ def test_up_mutliple_modes(
                         "up",
                         "redis",
                         "-d",
+                        "--pull",
+                        "always",
                     ],
                     check=True,
                     capture_output=True,
@@ -553,6 +579,8 @@ def test_up_multiple_modes_overlapping_running_service(
                             "up",
                             "clickhouse",
                             "-d",
+                            "--pull",
+                            "always",
                         ],
                         mock.ANY,
                     ),


### PR DESCRIPTION
Currently, we do not explicitly pull new images when bringing up containers. This change aims to fix that by setting the `pull policy` to `always`.