### PR TITLE
fix(purge): Updating purge to stop/remove all devservices containers

### DIFF
--- a/devservices/utils/docker.py
+++ b/devservices/utils/docker.py
@@ -89,6 +89,7 @@ def get_matching_containers(label: str) -> list[str]:
                 [
                     "docker",
                     "ps",
+                    "-a",
                     "-q",
                     "--filter",
                     f"label={label}",

--- a/tests/commands/test_purge.py
+++ b/tests/commands/test_purge.py
@@ -280,10 +280,7 @@ def test_purge_docker_error_stop_containers(
         )
 
         captured = capsys.readouterr()
-        assert (
-            "Failed to stop running devservices containers stderr"
-            in captured.out.strip()
-        )
+        assert "Failed to stop devservices containers stderr" in captured.out.strip()
 
 
 @mock.patch("devservices.commands.purge.get_matching_containers")
@@ -418,18 +415,21 @@ def test_purge_docker_error_remove_networks(
 
 
 @mock.patch("devservices.commands.purge.get_matching_containers")
+@mock.patch("devservices.commands.purge.get_matching_networks")
 @mock.patch("devservices.commands.purge.get_volumes_for_containers")
 @mock.patch("devservices.commands.purge.stop_containers")
 @mock.patch("devservices.commands.purge.remove_docker_resources")
-def test_purge_with_cache_and_state_and_no_running_containers(
+def test_purge_with_cache_and_state_and_no_containers(
     mock_remove_docker_resources: mock.Mock,
     mock_stop_containers: mock.Mock,
     mock_get_volumes_for_containers: mock.Mock,
+    mock_get_matching_networks: mock.Mock,
     mock_get_matching_containers: mock.Mock,
     tmp_path: Path,
 ) -> None:
     mock_get_matching_containers.return_value = []
     mock_get_volumes_for_containers.return_value = []
+    mock_get_matching_networks.return_value = []
     with (
         mock.patch(
             "devservices.commands.purge.DEVSERVICES_CACHE_DIR",
@@ -467,7 +467,7 @@ def test_purge_with_cache_and_state_and_no_running_containers(
 @mock.patch("devservices.commands.purge.get_volumes_for_containers")
 @mock.patch("devservices.commands.purge.stop_containers")
 @mock.patch("devservices.commands.purge.remove_docker_resources")
-def test_purge_with_cache_and_state_and_running_containers_with_networks_and_volumes(
+def test_purge_with_cache_and_state_and_containers_with_networks_and_volumes(
     mock_remove_docker_resources: mock.Mock,
     mock_stop_containers: mock.Mock,
     mock_get_volumes_for_containers: mock.Mock,

--- a/tests/utils/test_docker.py
+++ b/tests/utils/test_docker.py
@@ -58,7 +58,14 @@ def test_get_matching_containers(
     matching_containers = get_matching_containers(DEVSERVICES_ORCHESTRATOR_LABEL)
     mock_check_docker_daemon_running.assert_called_once()
     mock_check_output.assert_called_once_with(
-        ["docker", "ps", "-q", "--filter", f"label={DEVSERVICES_ORCHESTRATOR_LABEL}"],
+        [
+            "docker",
+            "ps",
+            "-a",
+            "-q",
+            "--filter",
+            f"label={DEVSERVICES_ORCHESTRATOR_LABEL}",
+        ],
         text=True,
         stderr=subprocess.DEVNULL,
     )
@@ -129,7 +136,14 @@ def test_get_matching_containers_error(
         get_matching_containers(DEVSERVICES_ORCHESTRATOR_LABEL)
     mock_check_docker_daemon_running.assert_called_once()
     mock_check_output.assert_called_once_with(
-        ["docker", "ps", "-q", "--filter", f"label={DEVSERVICES_ORCHESTRATOR_LABEL}"],
+        [
+            "docker",
+            "ps",
+            "-a",
+            "-q",
+            "--filter",
+            f"label={DEVSERVICES_ORCHESTRATOR_LABEL}",
+        ],
         text=True,
         stderr=subprocess.DEVNULL,
     )


### PR DESCRIPTION
Currently, we only stop/remove running devservices containers during purge which means there is an edge case where problematic containers are not running and thus are not removed by purge. This can lead to issues such as "network not found" errors when starting up.
https://getsentry.atlassian.net/browse/DEVINFRA-565