### PR TITLE
fix: Add missing dependencies to pyproject.toml

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -10,6 +10,8 @@ requires-python = ">=3.10"
 dependencies = [
     "pyyaml",
     "sentry-devenv",
+    "sentry-sdk",
+    "packaging",
 ]
 
 [project.optional-dependencies]


### PR DESCRIPTION
This should resolve errors if packaging/sentry_sdk is not installed by default