### PR TITLE
chore(state): Refactor state to support starting services table

### DIFF
--- a/devservices/commands/down.py
+++ b/devservices/commands/down.py
@@ -76,13 +76,13 @@ def down(args: Namespace) -> None:
     modes = service.config.modes
 
     state = State()
-    started_services = state.get_service_entries(StateTables.STARTED_SERVICES_TABLE)
+    started_services = state.get_service_entries(StateTables.STARTED_SERVICES)
     if service.name not in started_services:
         console.warning(f"{service.name} is not running")
         exit(0)
 
     active_modes = state.get_active_modes_for_service(
-        service.name, StateTables.STARTED_SERVICES_TABLE
+        service.name, StateTables.STARTED_SERVICES
     )
     mode_dependencies = set()
     for active_mode in active_modes:
@@ -116,7 +116,7 @@ def down(args: Namespace) -> None:
         for other_started_service in other_started_services:
             other_service = find_matching_service(other_started_service)
             other_service_active_modes = state.get_active_modes_for_service(
-                other_service.name, StateTables.STARTED_SERVICES_TABLE
+                other_service.name, StateTables.STARTED_SERVICES
             )
             dependency_graph = construct_dependency_graph(
                 other_service, other_service_active_modes
@@ -141,7 +141,7 @@ def down(args: Namespace) -> None:
 
     # TODO: We should factor in healthchecks here before marking service as not running
     state = State()
-    state.remove_service_entry(service.name, StateTables.STARTED_SERVICES_TABLE)
+    state.remove_service_entry(service.name, StateTables.STARTED_SERVICES)
     if dependent_service_name is None:
         console.success(f"{service.name} stopped")
 

--- a/devservices/commands/down.py
+++ b/devservices/commands/down.py
@@ -31,6 +31,7 @@ from devservices.utils.docker_compose import run_cmd
 from devservices.utils.services import find_matching_service
 from devservices.utils.services import Service
 from devservices.utils.state import State
+from devservices.utils.state import StateTables
 
 
 def add_parser(subparsers: _SubParsersAction[ArgumentParser]) -> None:
@@ -75,12 +76,14 @@ def down(args: Namespace) -> None:
     modes = service.config.modes
 
     state = State()
-    started_services = state.get_started_services()
+    started_services = state.get_service_entries(StateTables.STARTED_SERVICES_TABLE)
     if service.name not in started_services:
         console.warning(f"{service.name} is not running")
         exit(0)
 
-    active_modes = state.get_active_modes_for_service(service.name)
+    active_modes = state.get_active_modes_for_service(
+        service.name, StateTables.STARTED_SERVICES_TABLE
+    )
     mode_dependencies = set()
     for active_mode in active_modes:
         active_mode_dependencies = modes.get(active_mode, [])
@@ -113,7 +116,7 @@ def down(args: Namespace) -> None:
         for other_started_service in other_started_services:
             other_service = find_matching_service(other_started_service)
             other_service_active_modes = state.get_active_modes_for_service(
-                other_service.name
+                other_service.name, StateTables.STARTED_SERVICES_TABLE
             )
             dependency_graph = construct_dependency_graph(
                 other_service, other_service_active_modes
@@ -138,7 +141,7 @@ def down(args: Namespace) -> None:
 
     # TODO: We should factor in healthchecks here before marking service as not running
     state = State()
-    state.remove_started_service(service.name)
+    state.remove_service_entry(service.name, StateTables.STARTED_SERVICES_TABLE)
     if dependent_service_name is None:
         console.success(f"{service.name} stopped")
 

--- a/devservices/commands/list_services.py
+++ b/devservices/commands/list_services.py
@@ -31,7 +31,7 @@ def list_services(args: Namespace) -> None:
     coderoot = get_coderoot()
     services = get_local_services(coderoot)
     state = State()
-    running_services = state.get_service_entries(StateTables.STARTED_SERVICES_TABLE)
+    running_services = state.get_service_entries(StateTables.STARTED_SERVICES)
 
     if not services:
         console.warning("No services found")
@@ -49,7 +49,7 @@ def list_services(args: Namespace) -> None:
     for service in services_to_show:
         status = "running" if service.name in running_services else "stopped"
         active_modes = state.get_active_modes_for_service(
-            service.name, StateTables.STARTED_SERVICES_TABLE
+            service.name, StateTables.STARTED_SERVICES
         )
         console.info(f"- {service.name}")
         console.info(f"  modes: {active_modes}")

--- a/devservices/commands/list_services.py
+++ b/devservices/commands/list_services.py
@@ -8,6 +8,7 @@ from devservices.utils.console import Console
 from devservices.utils.devenv import get_coderoot
 from devservices.utils.services import get_local_services
 from devservices.utils.state import State
+from devservices.utils.state import StateTables
 
 
 def add_parser(subparsers: _SubParsersAction[ArgumentParser]) -> None:
@@ -30,7 +31,7 @@ def list_services(args: Namespace) -> None:
     coderoot = get_coderoot()
     services = get_local_services(coderoot)
     state = State()
-    running_services = state.get_started_services()
+    running_services = state.get_service_entries(StateTables.STARTED_SERVICES_TABLE)
 
     if not services:
         console.warning("No services found")
@@ -47,7 +48,9 @@ def list_services(args: Namespace) -> None:
 
     for service in services_to_show:
         status = "running" if service.name in running_services else "stopped"
-        active_modes = state.get_active_modes_for_service(service.name)
+        active_modes = state.get_active_modes_for_service(
+            service.name, StateTables.STARTED_SERVICES_TABLE
+        )
         console.info(f"- {service.name}")
         console.info(f"  modes: {active_modes}")
         console.info(f"  status: {status}")

--- a/devservices/commands/logs.py
+++ b/devservices/commands/logs.py
@@ -28,6 +28,7 @@ from devservices.utils.docker_compose import run_cmd
 from devservices.utils.services import find_matching_service
 from devservices.utils.services import Service
 from devservices.utils.state import State
+from devservices.utils.state import StateTables
 
 
 def add_parser(subparsers: _SubParsersAction[ArgumentParser]) -> None:
@@ -67,7 +68,7 @@ def logs(args: Namespace) -> None:
     mode_dependencies = modes[mode_to_use]
 
     state = State()
-    running_services = state.get_started_services()
+    running_services = state.get_service_entries(StateTables.STARTED_SERVICES_TABLE)
     if service.name not in running_services:
         console.warning(f"Service {service.name} is not running")
         return

--- a/devservices/commands/logs.py
+++ b/devservices/commands/logs.py
@@ -68,7 +68,7 @@ def logs(args: Namespace) -> None:
     mode_dependencies = modes[mode_to_use]
 
     state = State()
-    running_services = state.get_service_entries(StateTables.STARTED_SERVICES_TABLE)
+    running_services = state.get_service_entries(StateTables.STARTED_SERVICES)
     if service.name not in running_services:
         console.warning(f"Service {service.name} is not running")
         return

--- a/devservices/commands/up.py
+++ b/devservices/commands/up.py
@@ -109,7 +109,7 @@ def up(args: Namespace) -> None:
             exit(1)
     # TODO: We should factor in healthchecks here before marking service as running
     state = State()
-    state.update_service_entry(service.name, mode, StateTables.STARTED_SERVICES_TABLE)
+    state.update_service_entry(service.name, mode, StateTables.STARTED_SERVICES)
 
 
 def _bring_up_dependency(

--- a/devservices/commands/up.py
+++ b/devservices/commands/up.py
@@ -34,6 +34,7 @@ from devservices.utils.docker_compose import run_cmd
 from devservices.utils.services import find_matching_service
 from devservices.utils.services import Service
 from devservices.utils.state import State
+from devservices.utils.state import StateTables
 
 
 def add_parser(subparsers: _SubParsersAction[ArgumentParser]) -> None:
@@ -108,7 +109,7 @@ def up(args: Namespace) -> None:
             exit(1)
     # TODO: We should factor in healthchecks here before marking service as running
     state = State()
-    state.update_started_service(service.name, mode)
+    state.update_service_entry(service.name, mode, StateTables.STARTED_SERVICES_TABLE)
 
 
 def _bring_up_dependency(

--- a/devservices/utils/dependencies.py
+++ b/devservices/utils/dependencies.py
@@ -38,6 +38,7 @@ from devservices.utils.file_lock import lock
 from devservices.utils.services import find_matching_service
 from devservices.utils.services import Service
 from devservices.utils.state import State
+from devservices.utils.state import StateTables
 
 RELEVANT_GIT_CONFIG_KEYS = [
     "init.defaultbranch",
@@ -261,7 +262,7 @@ def get_non_shared_remote_dependencies(
     service_to_stop: Service, remote_dependencies: set[InstalledRemoteDependency]
 ) -> set[InstalledRemoteDependency]:
     state = State()
-    started_services = state.get_started_services()
+    started_services = state.get_service_entries(StateTables.STARTED_SERVICES_TABLE)
     # We don't care about the remote dependencies of the service we are stopping
     started_services.remove(service_to_stop.name)
     other_running_remote_dependencies: set[InstalledRemoteDependency] = set()

--- a/devservices/utils/dependencies.py
+++ b/devservices/utils/dependencies.py
@@ -262,7 +262,7 @@ def get_non_shared_remote_dependencies(
     service_to_stop: Service, remote_dependencies: set[InstalledRemoteDependency]
 ) -> set[InstalledRemoteDependency]:
     state = State()
-    started_services = state.get_service_entries(StateTables.STARTED_SERVICES_TABLE)
+    started_services = state.get_service_entries(StateTables.STARTED_SERVICES)
     # We don't care about the remote dependencies of the service we are stopping
     started_services.remove(service_to_stop.name)
     other_running_remote_dependencies: set[InstalledRemoteDependency] = set()

--- a/devservices/utils/state.py
+++ b/devservices/utils/state.py
@@ -2,13 +2,13 @@ from __future__ import annotations
 
 import os
 import sqlite3
-from enum import StrEnum
+from enum import Enum
 
 from devservices.constants import DEVSERVICES_LOCAL_DIR
 from devservices.constants import STATE_DB_FILE
 
 
-class StateTables(StrEnum):
+class StateTables(Enum):
     STARTED_SERVICES_TABLE = "started_services"
     STARTING_SERVICES_TABLE = "starting_services"
 

--- a/devservices/utils/state.py
+++ b/devservices/utils/state.py
@@ -9,8 +9,8 @@ from devservices.constants import STATE_DB_FILE
 
 
 class StateTables(Enum):
-    STARTED_SERVICES_TABLE = "started_services"
-    STARTING_SERVICES_TABLE = "starting_services"
+    STARTED_SERVICES = "started_services"
+    STARTING_SERVICES = "starting_services"
 
 
 class State:
@@ -30,9 +30,10 @@ class State:
 
     def initialize_database(self) -> None:
         cursor = self.conn.cursor()
+        # Formatted strings here and throughout the fileshould be extremely low risk given these are constants
         cursor.execute(
             f"""
-            CREATE TABLE IF NOT EXISTS {StateTables.STARTED_SERVICES_TABLE.value} (
+            CREATE TABLE IF NOT EXISTS {StateTables.STARTED_SERVICES.value} (
                 service_name TEXT PRIMARY KEY,
                 mode TEXT,
                 timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP
@@ -42,7 +43,7 @@ class State:
 
         cursor.execute(
             f"""
-            CREATE TABLE IF NOT EXISTS {StateTables.STARTING_SERVICES_TABLE.value} (
+            CREATE TABLE IF NOT EXISTS {StateTables.STARTING_SERVICES.value} (
                 service_name TEXT PRIMARY KEY,
                 mode TEXT,
                 timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP
@@ -113,12 +114,12 @@ class State:
         cursor = self.conn.cursor()
         cursor.execute(
             f"""
-            DELETE FROM {StateTables.STARTED_SERVICES_TABLE.value}
+            DELETE FROM {StateTables.STARTED_SERVICES.value}
         """
         )
         cursor.execute(
             f"""
-            DELETE FROM {StateTables.STARTING_SERVICES_TABLE.value}
+            DELETE FROM {StateTables.STARTING_SERVICES.value}
         """
         )
         self.conn.commit()

--- a/devservices/utils/state.py
+++ b/devservices/utils/state.py
@@ -2,9 +2,15 @@ from __future__ import annotations
 
 import os
 import sqlite3
+from enum import StrEnum
 
 from devservices.constants import DEVSERVICES_LOCAL_DIR
 from devservices.constants import STATE_DB_FILE
+
+
+class StateTables(StrEnum):
+    STARTED_SERVICES_TABLE = "started_services"
+    STARTING_SERVICES_TABLE = "starting_services"
 
 
 class State:
@@ -25,8 +31,18 @@ class State:
     def initialize_database(self) -> None:
         cursor = self.conn.cursor()
         cursor.execute(
-            """
-            CREATE TABLE IF NOT EXISTS started_services (
+            f"""
+            CREATE TABLE IF NOT EXISTS {StateTables.STARTED_SERVICES_TABLE.value} (
+                service_name TEXT PRIMARY KEY,
+                mode TEXT,
+                timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP
+            )
+        """
+        )
+
+        cursor.execute(
+            f"""
+            CREATE TABLE IF NOT EXISTS {StateTables.STARTING_SERVICES_TABLE.value} (
                 service_name TEXT PRIMARY KEY,
                 mode TEXT,
                 timestamp TIMESTAMP DEFAULT CURRENT_TIMESTAMP
@@ -35,52 +51,56 @@ class State:
         )
         self.conn.commit()
 
-    def update_started_service(self, service_name: str, mode: str) -> None:
+    def update_service_entry(
+        self, service_name: str, mode: str, table: StateTables
+    ) -> None:
         cursor = self.conn.cursor()
-        started_services = self.get_started_services()
-        active_modes = self.get_active_modes_for_service(service_name)
-        if service_name in started_services and mode in active_modes:
+        service_entries = self.get_service_entries(table)
+        active_modes = self.get_active_modes_for_service(service_name, table)
+        if service_name in service_entries and mode in active_modes:
             return
-        if service_name in started_services:
+        if service_name in service_entries:
             cursor.execute(
-                """
-                UPDATE started_services SET mode = ? WHERE service_name = ?
+                f"""
+                UPDATE {table.value} SET mode = ? WHERE service_name = ?
             """,
                 (",".join(active_modes + [mode]), service_name),
             )
         else:
             cursor.execute(
-                """
-                INSERT INTO started_services (service_name, mode) VALUES (?, ?)
+                f"""
+                INSERT INTO {table.value} (service_name, mode) VALUES (?, ?)
             """,
                 (service_name, ",".join(active_modes + [mode])),
             )
         self.conn.commit()
 
-    def remove_started_service(self, service_name: str) -> None:
+    def remove_service_entry(self, service_name: str, table: StateTables) -> None:
         cursor = self.conn.cursor()
         cursor.execute(
-            """
-            DELETE FROM started_services WHERE service_name = ?
+            f"""
+            DELETE FROM {table.value} WHERE service_name = ?
         """,
             (service_name,),
         )
         self.conn.commit()
 
-    def get_started_services(self) -> list[str]:
+    def get_service_entries(self, table: StateTables) -> list[str]:
         cursor = self.conn.cursor()
         cursor.execute(
-            """
-            SELECT service_name FROM started_services
+            f"""
+            SELECT service_name FROM {table.value}
         """
         )
         return [row[0] for row in cursor.fetchall()]
 
-    def get_active_modes_for_service(self, service_name: str) -> list[str]:
+    def get_active_modes_for_service(
+        self, service_name: str, table: StateTables
+    ) -> list[str]:
         cursor = self.conn.cursor()
         cursor.execute(
-            """
-            SELECT mode FROM started_services WHERE service_name = ?
+            f"""
+            SELECT mode FROM {table.value} WHERE service_name = ?
         """,
             (service_name,),
         )
@@ -92,8 +112,13 @@ class State:
     def clear_state(self) -> None:
         cursor = self.conn.cursor()
         cursor.execute(
-            """
-            DELETE FROM started_services
+            f"""
+            DELETE FROM {StateTables.STARTED_SERVICES_TABLE.value}
+        """
+        )
+        cursor.execute(
+            f"""
+            DELETE FROM {StateTables.STARTING_SERVICES_TABLE.value}
         """
         )
         self.conn.commit()

--- a/tests/commands/test_down.py
+++ b/tests/commands/test_down.py
@@ -76,7 +76,7 @@ def test_down_simple(
         ):
             state = State()
             state.update_service_entry(
-                "example-service", "default", StateTables.STARTED_SERVICES_TABLE
+                "example-service", "default", StateTables.STARTED_SERVICES
             )
             down(args)
 
@@ -106,7 +106,7 @@ def test_down_simple(
         )
 
         mock_remove_service_entry.assert_called_with(
-            "example-service", StateTables.STARTED_SERVICES_TABLE
+            "example-service", StateTables.STARTED_SERVICES
         )
 
         captured = capsys.readouterr()
@@ -175,7 +175,7 @@ def test_down_error(
     with mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")):
         state = State()
         state.update_service_entry(
-            "example-service", "default", StateTables.STARTED_SERVICES_TABLE
+            "example-service", "default", StateTables.STARTED_SERVICES
         )
         with pytest.raises(SystemExit):
             down(args)
@@ -241,7 +241,7 @@ def test_down_mode_simple(
         ):
             state = State()
             state.update_service_entry(
-                "example-service", "test", StateTables.STARTED_SERVICES_TABLE
+                "example-service", "test", StateTables.STARTED_SERVICES
             )
             down(args)
 
@@ -270,7 +270,7 @@ def test_down_mode_simple(
         )
 
         mock_remove_service_entry.assert_called_with(
-            "example-service", StateTables.STARTED_SERVICES_TABLE
+            "example-service", StateTables.STARTED_SERVICES
         )
 
         captured = capsys.readouterr()
@@ -401,10 +401,10 @@ def test_down_overlapping_services(
 
         state = State()
         state.update_service_entry(
-            "example-service", "default", StateTables.STARTED_SERVICES_TABLE
+            "example-service", "default", StateTables.STARTED_SERVICES
         )
         state.update_service_entry(
-            "other-service", "default", StateTables.STARTED_SERVICES_TABLE
+            "other-service", "default", StateTables.STARTED_SERVICES
         )
 
         args = Namespace(service_name=None, debug=False)
@@ -441,7 +441,7 @@ def test_down_overlapping_services(
 
         # example-service should be stopped
         mock_remove_service_entry.assert_called_with(
-            "example-service", StateTables.STARTED_SERVICES_TABLE
+            "example-service", StateTables.STARTED_SERVICES
         )
 
 
@@ -586,10 +586,10 @@ def test_down_does_not_stop_service_being_used_by_another_service(
 
         state = State()
         state.update_service_entry(
-            "example-service", "default", StateTables.STARTED_SERVICES_TABLE
+            "example-service", "default", StateTables.STARTED_SERVICES
         )
         state.update_service_entry(
-            "other-service", "default", StateTables.STARTED_SERVICES_TABLE
+            "other-service", "default", StateTables.STARTED_SERVICES
         )
 
         args = Namespace(service_name=None, debug=False)
@@ -604,7 +604,7 @@ def test_down_does_not_stop_service_being_used_by_another_service(
 
         # example-service should be stopped
         mock_remove_service_entry.assert_called_with(
-            "example-service", StateTables.STARTED_SERVICES_TABLE
+            "example-service", StateTables.STARTED_SERVICES
         )
 
 
@@ -756,10 +756,10 @@ def test_down_does_not_stop_nested_service_being_used_by_another_service(
 
         state = State()
         state.update_service_entry(
-            "child-service", "default", StateTables.STARTED_SERVICES_TABLE
+            "child-service", "default", StateTables.STARTED_SERVICES
         )
         state.update_service_entry(
-            "grandparent-service", "default", StateTables.STARTED_SERVICES_TABLE
+            "grandparent-service", "default", StateTables.STARTED_SERVICES
         )
 
         args = Namespace(service_name=None, debug=False)
@@ -774,7 +774,7 @@ def test_down_does_not_stop_nested_service_being_used_by_another_service(
 
         # child-service should be stopped
         mock_remove_service_entry.assert_called_with(
-            "child-service", StateTables.STARTED_SERVICES_TABLE
+            "child-service", StateTables.STARTED_SERVICES
         )
 
 
@@ -856,11 +856,9 @@ def test_down_overlapping_non_remote_services(
 
         state = State()
         state.update_service_entry(
-            "example-service", "default", StateTables.STARTED_SERVICES_TABLE
+            "example-service", "default", StateTables.STARTED_SERVICES
         )
-        state.update_service_entry(
-            "redis", "default", StateTables.STARTED_SERVICES_TABLE
-        )
+        state.update_service_entry("redis", "default", StateTables.STARTED_SERVICES)
 
         args = Namespace(service_name=None, debug=False)
 
@@ -892,5 +890,5 @@ def test_down_overlapping_non_remote_services(
 
         # example-service should be stopped
         mock_remove_service_entry.assert_called_with(
-            "example-service", StateTables.STARTED_SERVICES_TABLE
+            "example-service", StateTables.STARTED_SERVICES
         )

--- a/tests/commands/test_down.py
+++ b/tests/commands/test_down.py
@@ -22,6 +22,7 @@ from devservices.utils.dependencies import install_and_verify_dependencies
 from devservices.utils.docker_compose import DockerComposeCommand
 from devservices.utils.services import Service
 from devservices.utils.state import State
+from devservices.utils.state import StateTables
 from testing.utils import create_config_file
 from testing.utils import create_mock_git_repo
 from testing.utils import run_git_command
@@ -35,9 +36,9 @@ from testing.utils import run_git_command
         stdout="clickhouse\nredis\n",
     ),
 )
-@mock.patch("devservices.utils.state.State.remove_started_service")
+@mock.patch("devservices.utils.state.State.remove_service_entry")
 def test_down_simple(
-    mock_remove_started_service: mock.Mock,
+    mock_remove_service_entry: mock.Mock,
     mock_run: mock.Mock,
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
@@ -74,7 +75,9 @@ def test_down_simple(
             "devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")
         ):
             state = State()
-            state.update_started_service("example-service", "default")
+            state.update_service_entry(
+                "example-service", "default", StateTables.STARTED_SERVICES_TABLE
+            )
             down(args)
 
         # Ensure the DEVSERVICES_DEPENDENCIES_CACHE_DIR_KEY is set and is relative
@@ -102,16 +105,18 @@ def test_down_simple(
             env=mock.ANY,
         )
 
-        mock_remove_started_service.assert_called_with("example-service")
+        mock_remove_service_entry.assert_called_with(
+            "example-service", StateTables.STARTED_SERVICES_TABLE
+        )
 
         captured = capsys.readouterr()
         assert "Stopping clickhouse" in captured.out.strip()
         assert "Stopping redis" in captured.out.strip()
 
 
-@mock.patch("devservices.utils.state.State.remove_started_service")
+@mock.patch("devservices.utils.state.State.remove_service_entry")
 def test_down_no_config_file(
-    mock_remove_started_service: mock.Mock,
+    mock_remove_service_entry: mock.Mock,
     capsys: pytest.CaptureFixture[str],
     tmp_path: Path,
 ) -> None:
@@ -130,13 +135,13 @@ def test_down_no_config_file(
         in captured.out.strip()
     )
 
-    mock_remove_started_service.assert_not_called()
+    mock_remove_service_entry.assert_not_called()
 
 
 @mock.patch("devservices.utils.docker_compose.subprocess.run")
-@mock.patch("devservices.utils.state.State.remove_started_service")
+@mock.patch("devservices.utils.state.State.remove_service_entry")
 def test_down_error(
-    mock_remove_started_service: mock.Mock,
+    mock_remove_service_entry: mock.Mock,
     mock_run: mock.Mock,
     capsys: pytest.CaptureFixture[str],
     tmp_path: Path,
@@ -169,7 +174,9 @@ def test_down_error(
 
     with mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")):
         state = State()
-        state.update_started_service("example-service", "default")
+        state.update_service_entry(
+            "example-service", "default", StateTables.STARTED_SERVICES_TABLE
+        )
         with pytest.raises(SystemExit):
             down(args)
 
@@ -180,7 +187,7 @@ def test_down_error(
         "Failed to stop example-service: Docker Compose error" in captured.out.strip()
     )
 
-    mock_remove_started_service.assert_not_called()
+    mock_remove_service_entry.assert_not_called()
 
     assert "Stopping clickhouse" not in captured.out.strip()
     assert "Stopping redis" not in captured.out.strip()
@@ -194,9 +201,9 @@ def test_down_error(
         stdout="clickhouse\nredis\n",
     ),
 )
-@mock.patch("devservices.utils.state.State.remove_started_service")
+@mock.patch("devservices.utils.state.State.remove_service_entry")
 def test_down_mode_simple(
-    mock_remove_started_service: mock.Mock,
+    mock_remove_service_entry: mock.Mock,
     mock_run: mock.Mock,
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
@@ -233,7 +240,9 @@ def test_down_mode_simple(
             "devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")
         ):
             state = State()
-            state.update_started_service("example-service", "test")
+            state.update_service_entry(
+                "example-service", "test", StateTables.STARTED_SERVICES_TABLE
+            )
             down(args)
 
         # Ensure the DEVSERVICES_DEPENDENCIES_CACHE_DIR_KEY is set and is relative
@@ -260,7 +269,9 @@ def test_down_mode_simple(
             env=mock.ANY,
         )
 
-        mock_remove_started_service.assert_called_with("example-service")
+        mock_remove_service_entry.assert_called_with(
+            "example-service", StateTables.STARTED_SERVICES_TABLE
+        )
 
         captured = capsys.readouterr()
         assert "Stopping redis" in captured.out.strip()
@@ -296,9 +307,9 @@ def test_down_service_not_found_error(
     assert "Service not found" in captured.out.strip()
 
 
-@mock.patch("devservices.utils.state.State.remove_started_service")
+@mock.patch("devservices.utils.state.State.remove_service_entry")
 def test_down_overlapping_services(
-    mock_remove_started_service: mock.Mock,
+    mock_remove_service_entry: mock.Mock,
     tmp_path: Path,
 ) -> None:
     """
@@ -389,8 +400,12 @@ def test_down_overlapping_services(
         os.chdir(example_service_path)
 
         state = State()
-        state.update_started_service("example-service", "default")
-        state.update_started_service("other-service", "default")
+        state.update_service_entry(
+            "example-service", "default", StateTables.STARTED_SERVICES_TABLE
+        )
+        state.update_service_entry(
+            "other-service", "default", StateTables.STARTED_SERVICES_TABLE
+        )
 
         args = Namespace(service_name=None, debug=False)
 
@@ -425,12 +440,14 @@ def test_down_overlapping_services(
             )
 
         # example-service should be stopped
-        mock_remove_started_service.assert_called_with("example-service")
+        mock_remove_service_entry.assert_called_with(
+            "example-service", StateTables.STARTED_SERVICES_TABLE
+        )
 
 
-@mock.patch("devservices.utils.state.State.remove_started_service")
+@mock.patch("devservices.utils.state.State.remove_service_entry")
 def test_down_does_not_stop_service_being_used_by_another_service(
-    mock_remove_started_service: mock.Mock,
+    mock_remove_service_entry: mock.Mock,
     tmp_path: Path,
 ) -> None:
     """
@@ -568,8 +585,12 @@ def test_down_does_not_stop_service_being_used_by_another_service(
         os.chdir(example_service_path)
 
         state = State()
-        state.update_started_service("example-service", "default")
-        state.update_started_service("other-service", "default")
+        state.update_service_entry(
+            "example-service", "default", StateTables.STARTED_SERVICES_TABLE
+        )
+        state.update_service_entry(
+            "other-service", "default", StateTables.STARTED_SERVICES_TABLE
+        )
 
         args = Namespace(service_name=None, debug=False)
 
@@ -582,12 +603,14 @@ def test_down_does_not_stop_service_being_used_by_another_service(
             mock_bring_down_dependency.assert_not_called()
 
         # example-service should be stopped
-        mock_remove_started_service.assert_called_with("example-service")
+        mock_remove_service_entry.assert_called_with(
+            "example-service", StateTables.STARTED_SERVICES_TABLE
+        )
 
 
-@mock.patch("devservices.utils.state.State.remove_started_service")
+@mock.patch("devservices.utils.state.State.remove_service_entry")
 def test_down_does_not_stop_nested_service_being_used_by_another_service(
-    mock_remove_started_service: mock.Mock,
+    mock_remove_service_entry: mock.Mock,
     tmp_path: Path,
 ) -> None:
     """
@@ -732,8 +755,12 @@ def test_down_does_not_stop_nested_service_being_used_by_another_service(
         os.chdir(child_service_path)
 
         state = State()
-        state.update_started_service("child-service", "default")
-        state.update_started_service("grandparent-service", "default")
+        state.update_service_entry(
+            "child-service", "default", StateTables.STARTED_SERVICES_TABLE
+        )
+        state.update_service_entry(
+            "grandparent-service", "default", StateTables.STARTED_SERVICES_TABLE
+        )
 
         args = Namespace(service_name=None, debug=False)
 
@@ -746,12 +773,14 @@ def test_down_does_not_stop_nested_service_being_used_by_another_service(
             mock_bring_down_dependency.assert_not_called()
 
         # child-service should be stopped
-        mock_remove_started_service.assert_called_with("child-service")
+        mock_remove_service_entry.assert_called_with(
+            "child-service", StateTables.STARTED_SERVICES_TABLE
+        )
 
 
-@mock.patch("devservices.utils.state.State.remove_started_service")
+@mock.patch("devservices.utils.state.State.remove_service_entry")
 def test_down_overlapping_non_remote_services(
-    mock_remove_started_service: mock.Mock,
+    mock_remove_service_entry: mock.Mock,
     tmp_path: Path,
 ) -> None:
     """
@@ -826,8 +855,12 @@ def test_down_overlapping_non_remote_services(
         os.chdir(example_service_path)
 
         state = State()
-        state.update_started_service("example-service", "default")
-        state.update_started_service("redis", "default")
+        state.update_service_entry(
+            "example-service", "default", StateTables.STARTED_SERVICES_TABLE
+        )
+        state.update_service_entry(
+            "redis", "default", StateTables.STARTED_SERVICES_TABLE
+        )
 
         args = Namespace(service_name=None, debug=False)
 
@@ -858,4 +891,6 @@ def test_down_overlapping_non_remote_services(
             )
 
         # example-service should be stopped
-        mock_remove_started_service.assert_called_with("example-service")
+        mock_remove_service_entry.assert_called_with(
+            "example-service", StateTables.STARTED_SERVICES_TABLE
+        )

--- a/tests/commands/test_list_services.py
+++ b/tests/commands/test_list_services.py
@@ -21,7 +21,7 @@ def test_list_running_services(
     ), mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")):
         state = State()
         state.update_service_entry(
-            "example-service", "default", StateTables.STARTED_SERVICES_TABLE
+            "example-service", "default", StateTables.STARTED_SERVICES
         )
         config = {
             "x-sentry-service-config": {
@@ -61,7 +61,7 @@ def test_list_all_services(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -
     ), mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")):
         state = State()
         state.update_service_entry(
-            "example-service", "default", StateTables.STARTED_SERVICES_TABLE
+            "example-service", "default", StateTables.STARTED_SERVICES
         )
         config = {
             "x-sentry-service-config": {

--- a/tests/commands/test_list_services.py
+++ b/tests/commands/test_list_services.py
@@ -8,6 +8,7 @@ import pytest
 
 from devservices.commands.list_services import list_services
 from devservices.utils.state import State
+from devservices.utils.state import StateTables
 from testing.utils import create_config_file
 
 
@@ -19,7 +20,9 @@ def test_list_running_services(
         return_value=str(tmp_path / "code"),
     ), mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")):
         state = State()
-        state.update_started_service("example-service", "default")
+        state.update_service_entry(
+            "example-service", "default", StateTables.STARTED_SERVICES_TABLE
+        )
         config = {
             "x-sentry-service-config": {
                 "version": 0.1,
@@ -57,7 +60,9 @@ def test_list_all_services(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -
         return_value=str(tmp_path / "code"),
     ), mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")):
         state = State()
-        state.update_started_service("example-service", "default")
+        state.update_service_entry(
+            "example-service", "default", StateTables.STARTED_SERVICES_TABLE
+        )
         config = {
             "x-sentry-service-config": {
                 "version": 0.1,

--- a/tests/commands/test_logs.py
+++ b/tests/commands/test_logs.py
@@ -20,11 +20,11 @@ from devservices.utils.services import Service
 
 @mock.patch("devservices.commands.logs.get_docker_compose_commands_to_run")
 @mock.patch("devservices.commands.logs.find_matching_service")
-@mock.patch("devservices.utils.state.State.get_started_services")
+@mock.patch("devservices.utils.state.State.get_service_entries")
 @mock.patch("devservices.commands.logs.install_and_verify_dependencies")
 def test_logs_no_specified_service_not_running(
     mock_install_and_verify_dependencies: mock.Mock,
-    mock_get_started_services: mock.Mock,
+    mock_get_service_entries: mock.Mock,
     mock_find_matching_service: mock.Mock,
     mock_get_docker_compose_commands_to_run: mock.Mock,
     capsys: pytest.CaptureFixture[str],
@@ -48,13 +48,13 @@ def test_logs_no_specified_service_not_running(
             ),
             repo_path=str(tmp_path / "example-service"),
         )
-        mock_get_started_services.return_value = []
+        mock_get_service_entries.return_value = []
         mock_find_matching_service.return_value = mock_service
 
         logs(args)
 
         mock_find_matching_service.assert_called_once_with(None)
-        mock_get_started_services.assert_called_once()
+        mock_get_service_entries.assert_called_once()
         mock_install_and_verify_dependencies.assert_not_called()
         mock_get_docker_compose_commands_to_run.assert_not_called()
 
@@ -65,13 +65,13 @@ def test_logs_no_specified_service_not_running(
 # TODO: Ideally we should also have tests that don't mock the intermediate functions
 @mock.patch("devservices.commands.logs.run_cmd")
 @mock.patch("devservices.commands.logs.find_matching_service")
-@mock.patch("devservices.utils.state.State.get_started_services")
+@mock.patch("devservices.utils.state.State.get_service_entries")
 @mock.patch("devservices.commands.logs.install_and_verify_dependencies")
 @mock.patch("devservices.utils.docker_compose.get_non_remote_services")
 def test_logs_no_specified_service_success(
     mock_get_non_remote_services: mock.Mock,
     mock_install_and_verify_dependencies: mock.Mock,
-    mock_get_started_services: mock.Mock,
+    mock_get_service_entries: mock.Mock,
     mock_find_matching_service: mock.Mock,
     mock_run_cmd: mock.Mock,
     capsys: pytest.CaptureFixture[str],
@@ -96,7 +96,7 @@ def test_logs_no_specified_service_success(
             repo_path=str(tmp_path / "example-service"),
         )
         mock_install_and_verify_dependencies.return_value = {}
-        mock_get_started_services.return_value = ["example-service"]
+        mock_get_service_entries.return_value = ["example-service"]
         mock_find_matching_service.return_value = mock_service
         mock_get_non_remote_services.return_value = {"redis", "clickhouse"}
         mock_run_cmd.return_value = subprocess.CompletedProcess(
@@ -125,7 +125,7 @@ def test_logs_no_specified_service_success(
         logs(args)
 
         mock_find_matching_service.assert_called_once_with(None)
-        mock_get_started_services.assert_called_once()
+        mock_get_service_entries.assert_called_once()
         mock_install_and_verify_dependencies.assert_called_once()
         mock_run_cmd.assert_called_once_with(
             [

--- a/tests/commands/test_purge.py
+++ b/tests/commands/test_purge.py
@@ -12,6 +12,7 @@ from devservices.constants import DOCKER_NETWORK_NAME
 from devservices.exceptions import DockerDaemonNotRunningError
 from devservices.exceptions import DockerError
 from devservices.utils.state import State
+from devservices.utils.state import StateTables
 
 
 @mock.patch("devservices.commands.purge.get_matching_containers")
@@ -41,16 +42,20 @@ def test_purge_docker_daemon_not_running(
         cache_file.write_text("This is a test cache file.")
 
         state = State()
-        state.update_started_service("test-service", "test-mode")
+        state.update_service_entry(
+            "test-service", "test-mode", StateTables.STARTED_SERVICES_TABLE
+        )
 
         assert cache_file.exists()
-        assert state.get_started_services() == ["test-service"]
+        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == [
+            "test-service"
+        ]
 
         args = Namespace()
         purge(args)
 
         assert not cache_file.exists()
-        assert state.get_started_services() == []
+        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == []
 
         mock_get_matching_containers.assert_called_once_with(
             DEVSERVICES_ORCHESTRATOR_LABEL
@@ -95,17 +100,21 @@ def test_purge_docker_error_get_matching_containers(
         cache_file.write_text("This is a test cache file.")
 
         state = State()
-        state.update_started_service("test-service", "test-mode")
+        state.update_service_entry(
+            "test-service", "test-mode", StateTables.STARTED_SERVICES_TABLE
+        )
 
         assert cache_file.exists()
-        assert state.get_started_services() == ["test-service"]
+        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == [
+            "test-service"
+        ]
 
         args = Namespace()
         with pytest.raises(SystemExit):
             purge(args)
 
         assert not cache_file.exists()
-        assert state.get_started_services() == []
+        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == []
 
         mock_get_matching_containers.assert_called_once_with(
             DEVSERVICES_ORCHESTRATOR_LABEL
@@ -148,17 +157,21 @@ def test_purge_docker_error_get_volumes_for_containers(
         cache_file.write_text("This is a test cache file.")
 
         state = State()
-        state.update_started_service("test-service", "test-mode")
+        state.update_service_entry(
+            "test-service", "test-mode", StateTables.STARTED_SERVICES_TABLE
+        )
 
         assert cache_file.exists()
-        assert state.get_started_services() == ["test-service"]
+        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == [
+            "test-service"
+        ]
 
         args = Namespace()
         with pytest.raises(SystemExit):
             purge(args)
 
         assert not cache_file.exists()
-        assert state.get_started_services() == []
+        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == []
 
         mock_get_matching_containers.assert_called_once_with(
             DEVSERVICES_ORCHESTRATOR_LABEL
@@ -204,17 +217,21 @@ def test_purge_docker_error_get_matching_networks(
         cache_file.write_text("This is a test cache file.")
 
         state = State()
-        state.update_started_service("test-service", "test-mode")
+        state.update_service_entry(
+            "test-service", "test-mode", StateTables.STARTED_SERVICES_TABLE
+        )
 
         assert cache_file.exists()
-        assert state.get_started_services() == ["test-service"]
+        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == [
+            "test-service"
+        ]
 
         args = Namespace()
         with pytest.raises(SystemExit):
             purge(args)
 
         assert not cache_file.exists()
-        assert state.get_started_services() == []
+        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == []
 
         mock_get_matching_containers.assert_called_once_with(
             DEVSERVICES_ORCHESTRATOR_LABEL
@@ -259,17 +276,21 @@ def test_purge_docker_error_stop_containers(
         cache_file.write_text("This is a test cache file.")
 
         state = State()
-        state.update_started_service("test-service", "test-mode")
+        state.update_service_entry(
+            "test-service", "test-mode", StateTables.STARTED_SERVICES_TABLE
+        )
 
         assert cache_file.exists()
-        assert state.get_started_services() == ["test-service"]
+        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == [
+            "test-service"
+        ]
 
         args = Namespace()
         with pytest.raises(SystemExit):
             purge(args)
 
         assert not cache_file.exists()
-        assert state.get_started_services() == []
+        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == []
 
         mock_get_matching_containers.assert_called_once_with(
             DEVSERVICES_ORCHESTRATOR_LABEL
@@ -318,16 +339,20 @@ def test_purge_docker_error_remove_volumes_continues_to_remove_networks(
         cache_file.write_text("This is a test cache file.")
 
         state = State()
-        state.update_started_service("test-service", "test-mode")
+        state.update_service_entry(
+            "test-service", "test-mode", StateTables.STARTED_SERVICES_TABLE
+        )
 
         assert cache_file.exists()
-        assert state.get_started_services() == ["test-service"]
+        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == [
+            "test-service"
+        ]
 
         args = Namespace()
         purge(args)
 
         assert not cache_file.exists()
-        assert state.get_started_services() == []
+        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == []
 
         mock_get_matching_containers.assert_called_once_with(
             DEVSERVICES_ORCHESTRATOR_LABEL
@@ -383,17 +408,21 @@ def test_purge_docker_error_remove_networks(
         cache_file.write_text("This is a test cache file.")
 
         state = State()
-        state.update_started_service("test-service", "test-mode")
+        state.update_service_entry(
+            "test-service", "test-mode", StateTables.STARTED_SERVICES_TABLE
+        )
 
         assert cache_file.exists()
-        assert state.get_started_services() == ["test-service"]
+        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == [
+            "test-service"
+        ]
 
         args = Namespace()
         with pytest.raises(SystemExit):
             purge(args)
 
         assert not cache_file.exists()
-        assert state.get_started_services() == []
+        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == []
 
         mock_get_matching_containers.assert_called_once_with(
             DEVSERVICES_ORCHESTRATOR_LABEL
@@ -447,16 +476,20 @@ def test_purge_with_cache_and_state_and_no_containers(
         cache_file.write_text("This is a test cache file.")
 
         state = State()
-        state.update_started_service("test-service", "test-mode")
+        state.update_service_entry(
+            "test-service", "test-mode", StateTables.STARTED_SERVICES_TABLE
+        )
 
         assert cache_file.exists()
-        assert state.get_started_services() == ["test-service"]
+        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == [
+            "test-service"
+        ]
 
         args = Namespace()
         purge(args)
 
         assert not cache_file.exists()
-        assert state.get_started_services() == []
+        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == []
 
         mock_stop_containers.assert_called_once_with([], should_remove=True)
         mock_remove_docker_resources.assert_not_called()
@@ -495,16 +528,20 @@ def test_purge_with_cache_and_state_and_containers_with_networks_and_volumes(
         cache_file.write_text("This is a test cache file.")
 
         state = State()
-        state.update_started_service("test-service", "test-mode")
+        state.update_service_entry(
+            "test-service", "test-mode", StateTables.STARTED_SERVICES_TABLE
+        )
 
         assert cache_file.exists()
-        assert state.get_started_services() == ["test-service"]
+        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == [
+            "test-service"
+        ]
 
         args = Namespace()
         purge(args)
 
         assert not cache_file.exists()
-        assert state.get_started_services() == []
+        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == []
 
         mock_stop_containers.assert_called_once_with(
             ["abc", "def", "ghe"], should_remove=True

--- a/tests/commands/test_purge.py
+++ b/tests/commands/test_purge.py
@@ -43,11 +43,11 @@ def test_purge_docker_daemon_not_running(
 
         state = State()
         state.update_service_entry(
-            "test-service", "test-mode", StateTables.STARTED_SERVICES_TABLE
+            "test-service", "test-mode", StateTables.STARTED_SERVICES
         )
 
         assert cache_file.exists()
-        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == [
+        assert state.get_service_entries(StateTables.STARTED_SERVICES) == [
             "test-service"
         ]
 
@@ -55,7 +55,7 @@ def test_purge_docker_daemon_not_running(
         purge(args)
 
         assert not cache_file.exists()
-        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == []
+        assert state.get_service_entries(StateTables.STARTED_SERVICES) == []
 
         mock_get_matching_containers.assert_called_once_with(
             DEVSERVICES_ORCHESTRATOR_LABEL
@@ -101,11 +101,11 @@ def test_purge_docker_error_get_matching_containers(
 
         state = State()
         state.update_service_entry(
-            "test-service", "test-mode", StateTables.STARTED_SERVICES_TABLE
+            "test-service", "test-mode", StateTables.STARTED_SERVICES
         )
 
         assert cache_file.exists()
-        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == [
+        assert state.get_service_entries(StateTables.STARTED_SERVICES) == [
             "test-service"
         ]
 
@@ -114,7 +114,7 @@ def test_purge_docker_error_get_matching_containers(
             purge(args)
 
         assert not cache_file.exists()
-        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == []
+        assert state.get_service_entries(StateTables.STARTED_SERVICES) == []
 
         mock_get_matching_containers.assert_called_once_with(
             DEVSERVICES_ORCHESTRATOR_LABEL
@@ -158,11 +158,11 @@ def test_purge_docker_error_get_volumes_for_containers(
 
         state = State()
         state.update_service_entry(
-            "test-service", "test-mode", StateTables.STARTED_SERVICES_TABLE
+            "test-service", "test-mode", StateTables.STARTED_SERVICES
         )
 
         assert cache_file.exists()
-        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == [
+        assert state.get_service_entries(StateTables.STARTED_SERVICES) == [
             "test-service"
         ]
 
@@ -171,7 +171,7 @@ def test_purge_docker_error_get_volumes_for_containers(
             purge(args)
 
         assert not cache_file.exists()
-        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == []
+        assert state.get_service_entries(StateTables.STARTED_SERVICES) == []
 
         mock_get_matching_containers.assert_called_once_with(
             DEVSERVICES_ORCHESTRATOR_LABEL
@@ -218,11 +218,11 @@ def test_purge_docker_error_get_matching_networks(
 
         state = State()
         state.update_service_entry(
-            "test-service", "test-mode", StateTables.STARTED_SERVICES_TABLE
+            "test-service", "test-mode", StateTables.STARTED_SERVICES
         )
 
         assert cache_file.exists()
-        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == [
+        assert state.get_service_entries(StateTables.STARTED_SERVICES) == [
             "test-service"
         ]
 
@@ -231,7 +231,7 @@ def test_purge_docker_error_get_matching_networks(
             purge(args)
 
         assert not cache_file.exists()
-        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == []
+        assert state.get_service_entries(StateTables.STARTED_SERVICES) == []
 
         mock_get_matching_containers.assert_called_once_with(
             DEVSERVICES_ORCHESTRATOR_LABEL
@@ -277,11 +277,11 @@ def test_purge_docker_error_stop_containers(
 
         state = State()
         state.update_service_entry(
-            "test-service", "test-mode", StateTables.STARTED_SERVICES_TABLE
+            "test-service", "test-mode", StateTables.STARTED_SERVICES
         )
 
         assert cache_file.exists()
-        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == [
+        assert state.get_service_entries(StateTables.STARTED_SERVICES) == [
             "test-service"
         ]
 
@@ -290,7 +290,7 @@ def test_purge_docker_error_stop_containers(
             purge(args)
 
         assert not cache_file.exists()
-        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == []
+        assert state.get_service_entries(StateTables.STARTED_SERVICES) == []
 
         mock_get_matching_containers.assert_called_once_with(
             DEVSERVICES_ORCHESTRATOR_LABEL
@@ -340,11 +340,11 @@ def test_purge_docker_error_remove_volumes_continues_to_remove_networks(
 
         state = State()
         state.update_service_entry(
-            "test-service", "test-mode", StateTables.STARTED_SERVICES_TABLE
+            "test-service", "test-mode", StateTables.STARTED_SERVICES
         )
 
         assert cache_file.exists()
-        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == [
+        assert state.get_service_entries(StateTables.STARTED_SERVICES) == [
             "test-service"
         ]
 
@@ -352,7 +352,7 @@ def test_purge_docker_error_remove_volumes_continues_to_remove_networks(
         purge(args)
 
         assert not cache_file.exists()
-        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == []
+        assert state.get_service_entries(StateTables.STARTED_SERVICES) == []
 
         mock_get_matching_containers.assert_called_once_with(
             DEVSERVICES_ORCHESTRATOR_LABEL
@@ -409,11 +409,11 @@ def test_purge_docker_error_remove_networks(
 
         state = State()
         state.update_service_entry(
-            "test-service", "test-mode", StateTables.STARTED_SERVICES_TABLE
+            "test-service", "test-mode", StateTables.STARTED_SERVICES
         )
 
         assert cache_file.exists()
-        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == [
+        assert state.get_service_entries(StateTables.STARTED_SERVICES) == [
             "test-service"
         ]
 
@@ -422,7 +422,7 @@ def test_purge_docker_error_remove_networks(
             purge(args)
 
         assert not cache_file.exists()
-        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == []
+        assert state.get_service_entries(StateTables.STARTED_SERVICES) == []
 
         mock_get_matching_containers.assert_called_once_with(
             DEVSERVICES_ORCHESTRATOR_LABEL
@@ -477,11 +477,11 @@ def test_purge_with_cache_and_state_and_no_containers(
 
         state = State()
         state.update_service_entry(
-            "test-service", "test-mode", StateTables.STARTED_SERVICES_TABLE
+            "test-service", "test-mode", StateTables.STARTED_SERVICES
         )
 
         assert cache_file.exists()
-        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == [
+        assert state.get_service_entries(StateTables.STARTED_SERVICES) == [
             "test-service"
         ]
 
@@ -489,7 +489,7 @@ def test_purge_with_cache_and_state_and_no_containers(
         purge(args)
 
         assert not cache_file.exists()
-        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == []
+        assert state.get_service_entries(StateTables.STARTED_SERVICES) == []
 
         mock_stop_containers.assert_called_once_with([], should_remove=True)
         mock_remove_docker_resources.assert_not_called()
@@ -529,11 +529,11 @@ def test_purge_with_cache_and_state_and_containers_with_networks_and_volumes(
 
         state = State()
         state.update_service_entry(
-            "test-service", "test-mode", StateTables.STARTED_SERVICES_TABLE
+            "test-service", "test-mode", StateTables.STARTED_SERVICES
         )
 
         assert cache_file.exists()
-        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == [
+        assert state.get_service_entries(StateTables.STARTED_SERVICES) == [
             "test-service"
         ]
 
@@ -541,7 +541,7 @@ def test_purge_with_cache_and_state_and_containers_with_networks_and_volumes(
         purge(args)
 
         assert not cache_file.exists()
-        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == []
+        assert state.get_service_entries(StateTables.STARTED_SERVICES) == []
 
         mock_stop_containers.assert_called_once_with(
             ["abc", "def", "ghe"], should_remove=True

--- a/tests/commands/test_up.py
+++ b/tests/commands/test_up.py
@@ -18,12 +18,13 @@ from devservices.exceptions import DependencyError
 from devservices.exceptions import DockerComposeError
 from devservices.exceptions import ServiceNotFoundError
 from devservices.utils.state import State
+from devservices.utils.state import StateTables
 from testing.utils import create_config_file
 from testing.utils import create_mock_git_repo
 from testing.utils import run_git_command
 
 
-@mock.patch("devservices.utils.state.State.update_started_service")
+@mock.patch("devservices.utils.state.State.update_service_entry")
 @mock.patch("devservices.commands.up._create_devservices_network")
 @mock.patch("devservices.commands.up.check_all_containers_healthy")
 @mock.patch(
@@ -34,7 +35,7 @@ def test_up_simple(
     mock_subprocess_check_output: mock.Mock,
     mock_check_all_containers_healthy: mock.Mock,
     mock_create_devservices_network: mock.Mock,
-    mock_update_started_service: mock.Mock,
+    mock_update_service_entry: mock.Mock,
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -120,7 +121,9 @@ def test_up_simple(
             ]
         )
 
-        mock_update_started_service.assert_called_with("example-service", "default")
+        mock_update_service_entry.assert_called_with(
+            "example-service", "default", StateTables.STARTED_SERVICES_TABLE
+        )
         mock_check_all_containers_healthy.assert_called_once()
         captured = capsys.readouterr()
         assert "Retrieving dependencies" in captured.out.strip()
@@ -129,7 +132,7 @@ def test_up_simple(
         assert "Starting redis" in captured.out.strip()
 
 
-@mock.patch("devservices.utils.state.State.update_started_service")
+@mock.patch("devservices.utils.state.State.update_service_entry")
 @mock.patch("devservices.commands.up._create_devservices_network")
 @mock.patch("devservices.commands.up.check_all_containers_healthy")
 @mock.patch("devservices.commands.up.subprocess.check_output")
@@ -137,7 +140,7 @@ def test_up_dependency_error(
     mock_subprocess_check_output: mock.Mock,
     mock_check_all_containers_healthy: mock.Mock,
     mock_create_devservices_network: mock.Mock,
-    mock_update_started_service: mock.Mock,
+    mock_update_service_entry: mock.Mock,
     capsys: pytest.CaptureFixture[str],
     tmp_path: Path,
 ) -> None:
@@ -180,7 +183,7 @@ def test_up_dependency_error(
 
         assert "DependencyError: example-repo (link) on branch" in captured.out.strip()
 
-        mock_update_started_service.assert_not_called()
+        mock_update_service_entry.assert_not_called()
 
         mock_subprocess_check_output.assert_not_called()
 
@@ -193,9 +196,9 @@ def test_up_dependency_error(
         assert "Starting redis" not in captured.out.strip()
 
 
-@mock.patch("devservices.utils.state.State.update_started_service")
+@mock.patch("devservices.utils.state.State.update_service_entry")
 def test_up_no_config_file(
-    mock_update_started_service: mock.Mock,
+    mock_update_service_entry: mock.Mock,
     capsys: pytest.CaptureFixture[str],
     tmp_path: Path,
 ) -> None:
@@ -214,10 +217,10 @@ def test_up_no_config_file(
         in captured.out.strip()
     )
 
-    mock_update_started_service.assert_not_called()
+    mock_update_service_entry.assert_not_called()
 
 
-@mock.patch("devservices.utils.state.State.update_started_service")
+@mock.patch("devservices.utils.state.State.update_service_entry")
 @mock.patch("devservices.commands.up._create_devservices_network")
 @mock.patch("devservices.commands.up.check_all_containers_healthy")
 @mock.patch(
@@ -232,7 +235,7 @@ def test_up_error(
     mock_subprocess_check_output: mock.Mock,
     mock_check_all_containers_healthy: mock.Mock,
     mock_create_devservices_network: mock.Mock,
-    mock_update_started_service: mock.Mock,
+    mock_update_service_entry: mock.Mock,
     capsys: pytest.CaptureFixture[str],
     tmp_path: Path,
 ) -> None:
@@ -284,7 +287,7 @@ def test_up_error(
         "Failed to start example-service: Docker Compose error" in captured.out.strip()
     )
 
-    mock_update_started_service.assert_not_called()
+    mock_update_service_entry.assert_not_called()
 
     assert "Retrieving dependencies" in captured.out.strip()
     assert "Starting 'example-service' in mode: 'default'" in captured.out.strip()
@@ -292,7 +295,7 @@ def test_up_error(
     assert "Starting redis" not in captured.out.strip()
 
 
-@mock.patch("devservices.utils.state.State.update_started_service")
+@mock.patch("devservices.utils.state.State.update_service_entry")
 @mock.patch("devservices.commands.up._create_devservices_network")
 @mock.patch("devservices.commands.up.check_all_containers_healthy")
 @mock.patch(
@@ -303,7 +306,7 @@ def test_up_docker_compose_container_lookup_error(
     mock_subprocess_check_output: mock.Mock,
     mock_check_all_containers_healthy: mock.Mock,
     mock_create_devservices_network: mock.Mock,
-    mock_update_started_service: mock.Mock,
+    mock_update_service_entry: mock.Mock,
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -395,7 +398,7 @@ def test_up_docker_compose_container_lookup_error(
             ]
         )
 
-        mock_update_started_service.assert_not_called()
+        mock_update_service_entry.assert_not_called()
         mock_check_all_containers_healthy.assert_not_called()
         captured = capsys.readouterr()
         assert "Retrieving dependencies" in captured.out.strip()
@@ -408,7 +411,7 @@ def test_up_docker_compose_container_lookup_error(
         )
 
 
-@mock.patch("devservices.utils.state.State.update_started_service")
+@mock.patch("devservices.utils.state.State.update_service_entry")
 @mock.patch("devservices.commands.up._create_devservices_network")
 @mock.patch(
     "devservices.commands.up.check_all_containers_healthy",
@@ -426,7 +429,7 @@ def test_up_docker_compose_container_healthcheck_failed(
     mock_subprocess_check_output: mock.Mock,
     mock_check_all_containers_healthy: mock.Mock,
     mock_create_devservices_network: mock.Mock,
-    mock_update_started_service: mock.Mock,
+    mock_update_service_entry: mock.Mock,
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -513,7 +516,7 @@ def test_up_docker_compose_container_healthcheck_failed(
             ]
         )
 
-        mock_update_started_service.assert_not_called()
+        mock_update_service_entry.assert_not_called()
         mock_check_all_containers_healthy.assert_called_once()
         captured = capsys.readouterr()
         assert "Retrieving dependencies" in captured.out.strip()
@@ -526,7 +529,7 @@ def test_up_docker_compose_container_healthcheck_failed(
         )
 
 
-@mock.patch("devservices.utils.state.State.update_started_service")
+@mock.patch("devservices.utils.state.State.update_service_entry")
 @mock.patch("devservices.commands.up._create_devservices_network")
 @mock.patch("devservices.commands.up.check_all_containers_healthy")
 @mock.patch(
@@ -537,7 +540,7 @@ def test_up_mode_simple(
     mock_subprocess_check_output: mock.Mock,
     mock_check_all_containers_healthy: mock.Mock,
     mock_create_devservices_network: mock.Mock,
-    mock_update_started_service: mock.Mock,
+    mock_update_service_entry: mock.Mock,
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -626,7 +629,9 @@ def test_up_mode_simple(
             ]
         )
 
-        mock_update_started_service.assert_called_with("example-service", "test")
+        mock_update_service_entry.assert_called_with(
+            "example-service", "test", StateTables.STARTED_SERVICES_TABLE
+        )
         mock_check_all_containers_healthy.assert_called_once()
         captured = capsys.readouterr()
         assert "Retrieving dependencies" in captured.out.strip()
@@ -634,11 +639,11 @@ def test_up_mode_simple(
         assert "Starting redis" in captured.out.strip()
 
 
-@mock.patch("devservices.utils.state.State.update_started_service")
+@mock.patch("devservices.utils.state.State.update_service_entry")
 @mock.patch("devservices.commands.up.check_all_containers_healthy")
 def test_up_mode_does_not_exist(
     mock_check_all_containers_healthy: mock.Mock,
-    mock_update_started_service: mock.Mock,
+    mock_update_service_entry: mock.Mock,
     tmp_path: Path,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
@@ -681,7 +686,7 @@ def test_up_mode_does_not_exist(
                 ),
             ) as mock_run_cmd,
             mock.patch(
-                "devservices.utils.state.State.get_started_services",
+                "devservices.utils.state.State.get_service_entries",
                 return_value=["example-service"],
             ),
         ):
@@ -697,7 +702,7 @@ def test_up_mode_does_not_exist(
             in captured.out.strip()
         )
 
-        mock_update_started_service.assert_not_called()
+        mock_update_service_entry.assert_not_called()
         mock_check_all_containers_healthy.assert_not_called()
 
         captured = capsys.readouterr()
@@ -743,7 +748,9 @@ def test_up_mutliple_modes(
         os.chdir(service_path)
 
         state = State()
-        state.update_started_service("example-service", "default")
+        state.update_service_entry(
+            "example-service", "default", StateTables.STARTED_SERVICES_TABLE
+        )
 
         args = Namespace(service_name=None, debug=False, mode="test")
         with (
@@ -875,8 +882,12 @@ def test_up_multiple_modes_overlapping_running_service(
         os.chdir(service_path)
 
         state = State()
-        state.update_started_service("example-service", "default")
-        state.update_started_service("other-service", "default")
+        state.update_service_entry(
+            "example-service", "default", StateTables.STARTED_SERVICES_TABLE
+        )
+        state.update_service_entry(
+            "other-service", "default", StateTables.STARTED_SERVICES_TABLE
+        )
 
         args = Namespace(service_name="example-service", debug=False, mode="test")
 

--- a/tests/commands/test_up.py
+++ b/tests/commands/test_up.py
@@ -122,7 +122,7 @@ def test_up_simple(
         )
 
         mock_update_service_entry.assert_called_with(
-            "example-service", "default", StateTables.STARTED_SERVICES_TABLE
+            "example-service", "default", StateTables.STARTED_SERVICES
         )
         mock_check_all_containers_healthy.assert_called_once()
         captured = capsys.readouterr()
@@ -630,7 +630,7 @@ def test_up_mode_simple(
         )
 
         mock_update_service_entry.assert_called_with(
-            "example-service", "test", StateTables.STARTED_SERVICES_TABLE
+            "example-service", "test", StateTables.STARTED_SERVICES
         )
         mock_check_all_containers_healthy.assert_called_once()
         captured = capsys.readouterr()
@@ -749,7 +749,7 @@ def test_up_mutliple_modes(
 
         state = State()
         state.update_service_entry(
-            "example-service", "default", StateTables.STARTED_SERVICES_TABLE
+            "example-service", "default", StateTables.STARTED_SERVICES
         )
 
         args = Namespace(service_name=None, debug=False, mode="test")
@@ -883,10 +883,10 @@ def test_up_multiple_modes_overlapping_running_service(
 
         state = State()
         state.update_service_entry(
-            "example-service", "default", StateTables.STARTED_SERVICES_TABLE
+            "example-service", "default", StateTables.STARTED_SERVICES
         )
         state.update_service_entry(
-            "other-service", "default", StateTables.STARTED_SERVICES_TABLE
+            "other-service", "default", StateTables.STARTED_SERVICES
         )
 
         args = Namespace(service_name="example-service", debug=False, mode="test")

--- a/tests/utils/test_dependencies.py
+++ b/tests/utils/test_dependencies.py
@@ -1436,12 +1436,8 @@ def test_get_non_shared_remote_dependencies_no_shared_dependencies(
 ) -> None:
     with mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")):
         state = State()
-        state.update_service_entry(
-            "service-1", "default", StateTables.STARTED_SERVICES_TABLE
-        )
-        state.update_service_entry(
-            "service-2", "default", StateTables.STARTED_SERVICES_TABLE
-        )
+        state.update_service_entry("service-1", "default", StateTables.STARTED_SERVICES)
+        state.update_service_entry("service-2", "default", StateTables.STARTED_SERVICES)
     service_to_stop = Service(
         name="service-1",
         repo_path="/path/to/service-1",
@@ -1515,12 +1511,8 @@ def test_get_non_shared_remote_dependencies_shared_dependencies(
 ) -> None:
     with mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")):
         state = State()
-        state.update_service_entry(
-            "service-1", "default", StateTables.STARTED_SERVICES_TABLE
-        )
-        state.update_service_entry(
-            "service-2", "default", StateTables.STARTED_SERVICES_TABLE
-        )
+        state.update_service_entry("service-1", "default", StateTables.STARTED_SERVICES)
+        state.update_service_entry("service-2", "default", StateTables.STARTED_SERVICES)
     service_to_stop = Service(
         name="service-1",
         repo_path="/path/to/service-1",
@@ -1587,12 +1579,8 @@ def test_get_non_shared_remote_dependencies_complex(
 ) -> None:
     with mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")):
         state = State()
-        state.update_service_entry(
-            "service-1", "default", StateTables.STARTED_SERVICES_TABLE
-        )
-        state.update_service_entry(
-            "service-2", "default", StateTables.STARTED_SERVICES_TABLE
-        )
+        state.update_service_entry("service-1", "default", StateTables.STARTED_SERVICES)
+        state.update_service_entry("service-2", "default", StateTables.STARTED_SERVICES)
     service_to_stop = Service(
         name="service-1",
         repo_path="/path/to/service-1",

--- a/tests/utils/test_dependencies.py
+++ b/tests/utils/test_dependencies.py
@@ -30,6 +30,7 @@ from devservices.utils.dependencies import InstalledRemoteDependency
 from devservices.utils.dependencies import verify_local_dependencies
 from devservices.utils.services import Service
 from devservices.utils.state import State
+from devservices.utils.state import StateTables
 from testing.utils import create_config_file
 from testing.utils import create_mock_git_repo
 from testing.utils import run_git_command
@@ -1435,8 +1436,12 @@ def test_get_non_shared_remote_dependencies_no_shared_dependencies(
 ) -> None:
     with mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")):
         state = State()
-        state.update_started_service("service-1", "default")
-        state.update_started_service("service-2", "default")
+        state.update_service_entry(
+            "service-1", "default", StateTables.STARTED_SERVICES_TABLE
+        )
+        state.update_service_entry(
+            "service-2", "default", StateTables.STARTED_SERVICES_TABLE
+        )
     service_to_stop = Service(
         name="service-1",
         repo_path="/path/to/service-1",
@@ -1510,8 +1515,12 @@ def test_get_non_shared_remote_dependencies_shared_dependencies(
 ) -> None:
     with mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")):
         state = State()
-        state.update_started_service("service-1", "default")
-        state.update_started_service("service-2", "default")
+        state.update_service_entry(
+            "service-1", "default", StateTables.STARTED_SERVICES_TABLE
+        )
+        state.update_service_entry(
+            "service-2", "default", StateTables.STARTED_SERVICES_TABLE
+        )
     service_to_stop = Service(
         name="service-1",
         repo_path="/path/to/service-1",
@@ -1578,8 +1587,12 @@ def test_get_non_shared_remote_dependencies_complex(
 ) -> None:
     with mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")):
         state = State()
-        state.update_started_service("service-1", "default")
-        state.update_started_service("service-2", "default")
+        state.update_service_entry(
+            "service-1", "default", StateTables.STARTED_SERVICES_TABLE
+        )
+        state.update_service_entry(
+            "service-2", "default", StateTables.STARTED_SERVICES_TABLE
+        )
     service_to_stop = Service(
         name="service-1",
         repo_path="/path/to/service-1",

--- a/tests/utils/test_state.py
+++ b/tests/utils/test_state.py
@@ -10,20 +10,20 @@ from devservices.utils.state import StateTables
 def test_state_simple(tmp_path: Path) -> None:
     with mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")):
         state = State()
-        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == []
+        assert state.get_service_entries(StateTables.STARTED_SERVICES) == []
 
 
 def test_state_update_service_entry(tmp_path: Path) -> None:
     with mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")):
         state = State()
         state.update_service_entry(
-            "example-service", "default", StateTables.STARTED_SERVICES_TABLE
+            "example-service", "default", StateTables.STARTED_SERVICES
         )
-        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == [
+        assert state.get_service_entries(StateTables.STARTED_SERVICES) == [
             "example-service"
         ]
         assert state.get_active_modes_for_service(
-            "example-service", StateTables.STARTED_SERVICES_TABLE
+            "example-service", StateTables.STARTED_SERVICES
         ) == ["default"]
 
 
@@ -31,49 +31,45 @@ def test_state_remove_service_entry(tmp_path: Path) -> None:
     with mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")):
         state = State()
         state.update_service_entry(
-            "example-service", "default", StateTables.STARTED_SERVICES_TABLE
+            "example-service", "default", StateTables.STARTED_SERVICES
         )
-        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == [
+        assert state.get_service_entries(StateTables.STARTED_SERVICES) == [
             "example-service"
         ]
         assert state.get_active_modes_for_service(
-            "example-service", StateTables.STARTED_SERVICES_TABLE
+            "example-service", StateTables.STARTED_SERVICES
         ) == ["default"]
-        state.remove_service_entry(
-            "example-service", StateTables.STARTED_SERVICES_TABLE
-        )
-        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == []
+        state.remove_service_entry("example-service", StateTables.STARTED_SERVICES)
+        assert state.get_service_entries(StateTables.STARTED_SERVICES) == []
 
 
 def test_state_remove_unknown_service(tmp_path: Path) -> None:
     with mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")):
         state = State()
-        state.remove_service_entry(
-            "unknown-service", StateTables.STARTED_SERVICES_TABLE
-        )
-        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == []
+        state.remove_service_entry("unknown-service", StateTables.STARTED_SERVICES)
+        assert state.get_service_entries(StateTables.STARTED_SERVICES) == []
 
 
 def test_start_service_twice(tmp_path: Path) -> None:
     with mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")):
         state = State()
         state.update_service_entry(
-            "example-service", "default", StateTables.STARTED_SERVICES_TABLE
+            "example-service", "default", StateTables.STARTED_SERVICES
         )
-        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == [
+        assert state.get_service_entries(StateTables.STARTED_SERVICES) == [
             "example-service"
         ]
         assert state.get_active_modes_for_service(
-            "example-service", StateTables.STARTED_SERVICES_TABLE
+            "example-service", StateTables.STARTED_SERVICES
         ) == ["default"]
         state.update_service_entry(
-            "example-service", "default", StateTables.STARTED_SERVICES_TABLE
+            "example-service", "default", StateTables.STARTED_SERVICES
         )
-        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == [
+        assert state.get_service_entries(StateTables.STARTED_SERVICES) == [
             "example-service"
         ]
         assert state.get_active_modes_for_service(
-            "example-service", StateTables.STARTED_SERVICES_TABLE
+            "example-service", StateTables.STARTED_SERVICES
         ) == ["default"]
 
 
@@ -82,7 +78,7 @@ def test_get_mode_for_nonexistent_service(tmp_path: Path) -> None:
         state = State()
         assert (
             state.get_active_modes_for_service(
-                "unknown-service", StateTables.STARTED_SERVICES_TABLE
+                "unknown-service", StateTables.STARTED_SERVICES
             )
             == []
         )

--- a/tests/utils/test_state.py
+++ b/tests/utils/test_state.py
@@ -4,51 +4,85 @@ from pathlib import Path
 from unittest import mock
 
 from devservices.utils.state import State
+from devservices.utils.state import StateTables
 
 
 def test_state_simple(tmp_path: Path) -> None:
     with mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")):
         state = State()
-        assert state.get_started_services() == []
+        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == []
 
 
-def test_state_update_started_service(tmp_path: Path) -> None:
+def test_state_update_service_entry(tmp_path: Path) -> None:
     with mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")):
         state = State()
-        state.update_started_service("example-service", "default")
-        assert state.get_started_services() == ["example-service"]
-        assert state.get_active_modes_for_service("example-service") == ["default"]
+        state.update_service_entry(
+            "example-service", "default", StateTables.STARTED_SERVICES_TABLE
+        )
+        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == [
+            "example-service"
+        ]
+        assert state.get_active_modes_for_service(
+            "example-service", StateTables.STARTED_SERVICES_TABLE
+        ) == ["default"]
 
 
-def test_state_remove_started_service(tmp_path: Path) -> None:
+def test_state_remove_service_entry(tmp_path: Path) -> None:
     with mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")):
         state = State()
-        state.update_started_service("example-service", "default")
-        assert state.get_started_services() == ["example-service"]
-        assert state.get_active_modes_for_service("example-service") == ["default"]
-        state.remove_started_service("example-service")
-        assert state.get_started_services() == []
+        state.update_service_entry(
+            "example-service", "default", StateTables.STARTED_SERVICES_TABLE
+        )
+        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == [
+            "example-service"
+        ]
+        assert state.get_active_modes_for_service(
+            "example-service", StateTables.STARTED_SERVICES_TABLE
+        ) == ["default"]
+        state.remove_service_entry(
+            "example-service", StateTables.STARTED_SERVICES_TABLE
+        )
+        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == []
 
 
 def test_state_remove_unknown_service(tmp_path: Path) -> None:
     with mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")):
         state = State()
-        state.remove_started_service("unknown-service")
-        assert state.get_started_services() == []
+        state.remove_service_entry(
+            "unknown-service", StateTables.STARTED_SERVICES_TABLE
+        )
+        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == []
 
 
 def test_start_service_twice(tmp_path: Path) -> None:
     with mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")):
         state = State()
-        state.update_started_service("example-service", "default")
-        assert state.get_started_services() == ["example-service"]
-        assert state.get_active_modes_for_service("example-service") == ["default"]
-        state.update_started_service("example-service", "default")
-        assert state.get_started_services() == ["example-service"]
-        assert state.get_active_modes_for_service("example-service") == ["default"]
+        state.update_service_entry(
+            "example-service", "default", StateTables.STARTED_SERVICES_TABLE
+        )
+        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == [
+            "example-service"
+        ]
+        assert state.get_active_modes_for_service(
+            "example-service", StateTables.STARTED_SERVICES_TABLE
+        ) == ["default"]
+        state.update_service_entry(
+            "example-service", "default", StateTables.STARTED_SERVICES_TABLE
+        )
+        assert state.get_service_entries(StateTables.STARTED_SERVICES_TABLE) == [
+            "example-service"
+        ]
+        assert state.get_active_modes_for_service(
+            "example-service", StateTables.STARTED_SERVICES_TABLE
+        ) == ["default"]
 
 
 def test_get_mode_for_nonexistent_service(tmp_path: Path) -> None:
     with mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")):
         state = State()
-        assert state.get_active_modes_for_service("unknown-service") == []
+        assert (
+            state.get_active_modes_for_service(
+                "unknown-service", StateTables.STARTED_SERVICES_TABLE
+            )
+            == []
+        )


### PR DESCRIPTION
This will allow us to support a `starting_services` table, allowing us to clean up intermediate states users may get into if `devservices up` fails. Then, `devservices down` will clean things up