### PR TITLE
ref(dependencies): Switching to debug logs and sentry messages

### DIFF
--- a/devservices/utils/dependencies.py
+++ b/devservices/utils/dependencies.py
@@ -13,6 +13,7 @@ from dataclasses import dataclass
 from typing import TextIO
 from typing import TypeGuard
 
+from sentry_sdk import capture_message
 from sentry_sdk import set_context
 
 from devservices.configs.service_config import Dependency
@@ -601,7 +602,10 @@ def _run_command_with_retries(
             break
         except subprocess.CalledProcessError as e:
             logger = logging.getLogger(LOGGER_NAME)
-            logger.exception("Attempt %s of %s failed: %s", i + 1, retries, e)
+            logger.debug("Attempt %s of %s failed: %s", i + 1, retries, e)
+            capture_message(
+                f"Attempt {i + 1} of {retries} for {cmd} failed: {e}", level="warning"
+            )
             if i == retries - 1:
                 raise e
             time.sleep(backoff**i)

--- a/devservices/utils/dependencies.py
+++ b/devservices/utils/dependencies.py
@@ -602,7 +602,7 @@ def _run_command_with_retries(
             break
         except subprocess.CalledProcessError as e:
             logger = logging.getLogger(LOGGER_NAME)
-            logger.debug("Attempt %s of %s failed: %s", i + 1, retries, e)
+            logger.debug("Attempt %s of %s for %s failed: %s", i + 1, retries, cmd, e)
             capture_message(
                 f"Attempt {i + 1} of {retries} for {cmd} failed: {e}", level="warning"
             )


### PR DESCRIPTION
Currently, we log this an exception when it isn't particularly actionable for users. While we don't need to show users about the retries, we still want to keep an eye on them to get a better idea of how often this issue occurs hence the use of capture_message.