### PR TITLE
ref(commands): Improving commands to use starting services and started

### DIFF
--- a/devservices/commands/list_services.py
+++ b/devservices/commands/list_services.py
@@ -53,7 +53,7 @@ def list_services(args: Namespace) -> None:
         if service.name in starting_services:
             status = "starting"
         elif service.name in started_services:
-            status = "Started"
+            status = "started"
         active_starting_modes = state.get_active_modes_for_service(
             service.name, StateTables.STARTING_SERVICES
         )

--- a/devservices/commands/list_services.py
+++ b/devservices/commands/list_services.py
@@ -53,7 +53,7 @@ def list_services(args: Namespace) -> None:
         if service.name in starting_services:
             status = "starting"
         elif service.name in started_services:
-            status = "running"
+            status = "Started"
         active_starting_modes = state.get_active_modes_for_service(
             service.name, StateTables.STARTING_SERVICES
         )

--- a/devservices/commands/logs.py
+++ b/devservices/commands/logs.py
@@ -68,7 +68,9 @@ def logs(args: Namespace) -> None:
     mode_dependencies = modes[mode_to_use]
 
     state = State()
-    running_services = state.get_service_entries(StateTables.STARTED_SERVICES)
+    starting_services = set(state.get_service_entries(StateTables.STARTING_SERVICES))
+    started_services = set(state.get_service_entries(StateTables.STARTED_SERVICES))
+    running_services = starting_services.union(started_services)
     if service.name not in running_services:
         console.warning(f"Service {service.name} is not running")
         return

--- a/tests/commands/test_list_services.py
+++ b/tests/commands/test_list_services.py
@@ -7,22 +7,27 @@ from unittest import mock
 import pytest
 
 from devservices.commands.list_services import list_services
-from devservices.utils.state import State
 from devservices.utils.state import StateTables
 from testing.utils import create_config_file
 
 
-def test_list_running_services(
-    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+@mock.patch("devservices.utils.state.State.get_service_entries")
+@mock.patch("devservices.utils.state.State.get_active_modes_for_service")
+def test_list_running_services_starting(
+    mock_get_active_modes_for_service: mock.Mock,
+    mock_get_service_entries: mock.Mock,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
 ) -> None:
-    with mock.patch(
-        "devservices.commands.list_services.get_coderoot",
-        return_value=str(tmp_path / "code"),
-    ), mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")):
-        state = State()
-        state.update_service_entry(
-            "example-service", "default", StateTables.STARTED_SERVICES
-        )
+    with (
+        mock.patch(
+            "devservices.commands.list_services.get_coderoot",
+            return_value=str(tmp_path / "code"),
+        ),
+        mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")),
+    ):
+        mock_get_service_entries.side_effect = [["example-service"], []]
+        mock_get_active_modes_for_service.side_effect = [["default"], []]
         config = {
             "x-sentry-service-config": {
                 "version": 0.1,
@@ -45,6 +50,68 @@ def test_list_running_services(
         args = Namespace(service_name=None, all=False)
         list_services(args)
 
+        mock_get_service_entries.assert_has_calls(
+            [
+                mock.call(StateTables.STARTING_SERVICES),
+                mock.call(StateTables.STARTED_SERVICES),
+            ]
+        )
+
+        # Capture the printed output
+        captured = capsys.readouterr()
+
+        assert (
+            captured.out
+            == f"Running services:\n- example-service\n  modes: ['default']\n  status: starting\n  location: {tmp_path / 'code' / 'example-service'}\n"
+        )
+
+
+@mock.patch("devservices.utils.state.State.get_service_entries")
+@mock.patch("devservices.utils.state.State.get_active_modes_for_service")
+def test_list_running_services_started(
+    mock_get_active_modes_for_service: mock.Mock,
+    mock_get_service_entries: mock.Mock,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with (
+        mock.patch(
+            "devservices.commands.list_services.get_coderoot",
+            return_value=str(tmp_path / "code"),
+        ),
+        mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")),
+    ):
+        mock_get_service_entries.side_effect = [[], ["example-service"]]
+        mock_get_active_modes_for_service.side_effect = [[], ["default"]]
+        config = {
+            "x-sentry-service-config": {
+                "version": 0.1,
+                "service_name": "example-service",
+                "dependencies": {
+                    "redis": {"description": "Redis"},
+                    "clickhouse": {"description": "Clickhouse"},
+                },
+                "modes": {"default": ["redis", "clickhouse"]},
+            },
+            "services": {
+                "redis": {"image": "redis:6.2.14-alpine"},
+                "clickhouse": {
+                    "image": "altinity/clickhouse-server:23.8.11.29.altinitystable"
+                },
+            },
+        }
+        create_config_file(tmp_path / "code" / "example-service", config)
+
+        args = Namespace(service_name=None, all=False)
+        list_services(args)
+
+        mock_get_service_entries.assert_has_calls(
+            [
+                mock.call(StateTables.STARTING_SERVICES),
+                mock.call(StateTables.STARTED_SERVICES),
+            ]
+        )
+
         # Capture the printed output
         captured = capsys.readouterr()
 
@@ -54,15 +121,23 @@ def test_list_running_services(
         )
 
 
-def test_list_all_services(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
-    with mock.patch(
-        "devservices.commands.list_services.get_coderoot",
-        return_value=str(tmp_path / "code"),
-    ), mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")):
-        state = State()
-        state.update_service_entry(
-            "example-service", "default", StateTables.STARTED_SERVICES
-        )
+@mock.patch("devservices.utils.state.State.get_service_entries")
+@mock.patch("devservices.utils.state.State.get_active_modes_for_service")
+def test_list_all_services(
+    mock_get_active_modes_for_service: mock.Mock,
+    mock_get_service_entries: mock.Mock,
+    tmp_path: Path,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with (
+        mock.patch(
+            "devservices.commands.list_services.get_coderoot",
+            return_value=str(tmp_path / "code"),
+        ),
+        mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")),
+    ):
+        mock_get_service_entries.side_effect = [[], ["example-service"]]
+        mock_get_active_modes_for_service.side_effect = [[], ["default"]]
         config = {
             "x-sentry-service-config": {
                 "version": 0.1,
@@ -84,6 +159,13 @@ def test_list_all_services(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -
 
         args = Namespace(service_name=None, all=True)
         list_services(args)
+
+        mock_get_service_entries.assert_has_calls(
+            [
+                mock.call(StateTables.STARTING_SERVICES),
+                mock.call(StateTables.STARTED_SERVICES),
+            ]
+        )
 
         # Capture the printed output
         captured = capsys.readouterr()

--- a/tests/commands/test_list_services.py
+++ b/tests/commands/test_list_services.py
@@ -117,7 +117,7 @@ def test_list_running_services_started(
 
         assert (
             captured.out
-            == f"Running services:\n- example-service\n  modes: ['default']\n  status: running\n  location: {tmp_path / 'code' / 'example-service'}\n"
+            == f"Running services:\n- example-service\n  modes: ['default']\n  status: started\n  location: {tmp_path / 'code' / 'example-service'}\n"
         )
 
 
@@ -172,5 +172,5 @@ def test_list_all_services(
 
         assert (
             captured.out
-            == f"Services installed locally:\n- example-service\n  modes: ['default']\n  status: running\n  location: {tmp_path / 'code' / 'example-service'}\n"
+            == f"Services installed locally:\n- example-service\n  modes: ['default']\n  status: started\n  location: {tmp_path / 'code' / 'example-service'}\n"
         )

--- a/tests/commands/test_logs.py
+++ b/tests/commands/test_logs.py
@@ -16,6 +16,7 @@ from devservices.constants import DEVSERVICES_DIR_NAME
 from devservices.exceptions import ConfigError
 from devservices.exceptions import ServiceNotFoundError
 from devservices.utils.services import Service
+from devservices.utils.state import StateTables
 
 
 @mock.patch("devservices.commands.logs.get_docker_compose_commands_to_run")
@@ -54,7 +55,16 @@ def test_logs_no_specified_service_not_running(
         logs(args)
 
         mock_find_matching_service.assert_called_once_with(None)
-        mock_get_service_entries.assert_called_once()
+        mock_get_service_entries.assert_has_calls(
+            [
+                mock.call(
+                    StateTables.STARTING_SERVICES,
+                ),
+                mock.call(
+                    StateTables.STARTED_SERVICES,
+                ),
+            ]
+        )
         mock_install_and_verify_dependencies.assert_not_called()
         mock_get_docker_compose_commands_to_run.assert_not_called()
 
@@ -125,7 +135,16 @@ def test_logs_no_specified_service_success(
         logs(args)
 
         mock_find_matching_service.assert_called_once_with(None)
-        mock_get_service_entries.assert_called_once()
+        mock_get_service_entries.assert_has_calls(
+            [
+                mock.call(
+                    StateTables.STARTING_SERVICES,
+                ),
+                mock.call(
+                    StateTables.STARTED_SERVICES,
+                ),
+            ]
+        )
         mock_install_and_verify_dependencies.assert_called_once()
         mock_run_cmd.assert_called_once_with(
             [


### PR DESCRIPTION
https://getsentry.atlassian.net/browse/DEVINFRA-596 Now that we track both starting and started services, commands such as `logs` and `list-services` should be able to work with starting services. This change updates those commands to do just that by treating both starting and started services as not-stopped (aka running).