### PR TITLE
ref(up): Show available modes

### DIFF
--- a/devservices/exceptions.py
+++ b/devservices/exceptions.py
@@ -77,12 +77,14 @@ class DockerComposeError(DockerError):
 class ModeDoesNotExistError(Exception):
     """Raised when a mode does not exist."""
 
-    def __init__(self, service_name: str, mode: str):
+    def __init__(self, service_name: str, mode: str, valid_modes: list[str]):
         self.service_name = service_name
         self.mode = mode
+        self.valid_modes = valid_modes
 
     def __str__(self) -> str:
-        return f"ModeDoesNotExistError: Mode '{self.mode}' does not exist for service '{self.service_name}'"
+        # All valid services should have at least one mode, so we don't check for an empty list
+        return f"ModeDoesNotExistError: Mode '{self.mode}' does not exist for service '{self.service_name}'.\nAvailable modes: {', '.join(self.valid_modes)}"
 
 
 class DependencyError(Exception):

--- a/devservices/exceptions.py
+++ b/devservices/exceptions.py
@@ -77,14 +77,14 @@ class DockerComposeError(DockerError):
 class ModeDoesNotExistError(Exception):
     """Raised when a mode does not exist."""
 
-    def __init__(self, service_name: str, mode: str, valid_modes: list[str]):
+    def __init__(self, service_name: str, mode: str, available_modes: list[str]):
         self.service_name = service_name
         self.mode = mode
-        self.valid_modes = valid_modes
+        self.available_modes = available_modes
 
     def __str__(self) -> str:
         # All valid services should have at least one mode, so we don't check for an empty list
-        return f"ModeDoesNotExistError: Mode '{self.mode}' does not exist for service '{self.service_name}'.\nAvailable modes: {', '.join(self.valid_modes)}"
+        return f"ModeDoesNotExistError: Mode '{self.mode}' does not exist for service '{self.service_name}'.\nAvailable modes: {', '.join(self.available_modes)}"
 
 
 class DependencyError(Exception):

--- a/devservices/utils/dependencies.py
+++ b/devservices/utils/dependencies.py
@@ -213,7 +213,7 @@ def install_and_verify_dependencies(
             raise ModeDoesNotExistError(
                 service_name=service.name,
                 mode=mode,
-                valid_modes=list(service.config.modes.keys()),
+                available_modes=list(service.config.modes.keys()),
             )
         mode_dependencies.update(service.config.modes[mode])
     matching_dependencies = [
@@ -416,7 +416,7 @@ def install_dependency(dependency: RemoteConfig) -> set[InstalledRemoteDependenc
         raise ModeDoesNotExistError(
             service_name=installed_config.service_name,
             mode=dependency.mode,
-            valid_modes=list(installed_config.modes.keys()),
+            available_modes=list(installed_config.modes.keys()),
         )
 
     active_nested_dependencies = [

--- a/devservices/utils/dependencies.py
+++ b/devservices/utils/dependencies.py
@@ -210,7 +210,11 @@ def install_and_verify_dependencies(
     mode_dependencies = set()
     for mode in modes:
         if mode not in service.config.modes:
-            raise ModeDoesNotExistError(service_name=service.name, mode=mode)
+            raise ModeDoesNotExistError(
+                service_name=service.name,
+                mode=mode,
+                valid_modes=list(service.config.modes.keys()),
+            )
         mode_dependencies.update(service.config.modes[mode])
     matching_dependencies = [
         dependency
@@ -412,6 +416,7 @@ def install_dependency(dependency: RemoteConfig) -> set[InstalledRemoteDependenc
         raise ModeDoesNotExistError(
             service_name=installed_config.service_name,
             mode=dependency.mode,
+            valid_modes=list(installed_config.modes.keys()),
         )
 
     active_nested_dependencies = [

--- a/tests/commands/test_up.py
+++ b/tests/commands/test_up.py
@@ -740,7 +740,7 @@ def test_up_mode_does_not_exist(
         captured = capsys.readouterr()
 
         assert (
-            "ModeDoesNotExistError: Mode 'test' does not exist for service 'example-service'"
+            "ModeDoesNotExistError: Mode 'test' does not exist for service 'example-service'.\nAvailable modes: default"
             in captured.out.strip()
         )
 


### PR DESCRIPTION
https://getsentry.atlassian.net/browse/DEVINFRA-594. Currently, there is no good way of seeing modes available to be run, and mistyping a mode doesn't give you any indication of possible options. This change fixes that by including available modes in the error message.