### PR TITLE
ref(dependencies): Improving error handling for dependency logic

### DIFF
--- a/devservices/utils/dependencies.py
+++ b/devservices/utils/dependencies.py
@@ -486,11 +486,7 @@ def _update_dependency(
 
     # Check if the local repo is up-to-date
     try:
-        local_commit = subprocess.check_output(
-            ["git", "rev-parse", "HEAD"],
-            cwd=dependency_repo_dir,
-            stderr=subprocess.PIPE,
-        ).strip()
+        local_commit = _rev_parse(dependency_repo_dir, "HEAD")
     except subprocess.CalledProcessError as e:
         raise DependencyError(
             repo_name=dependency.repo_name,
@@ -499,11 +495,7 @@ def _update_dependency(
         ) from e
 
     try:
-        remote_commit = subprocess.check_output(
-            ["git", "rev-parse", "FETCH_HEAD"],
-            cwd=dependency_repo_dir,
-            stderr=subprocess.PIPE,
-        ).strip()
+        remote_commit = _rev_parse(dependency_repo_dir, "FETCH_HEAD")
     except subprocess.CalledProcessError as e:
         raise DependencyError(
             repo_name=dependency.repo_name,
@@ -620,6 +612,16 @@ def _get_remote_configs(dependencies: list[Dependency]) -> list[RemoteConfig]:
 
 def _has_remote_config(remote_config: RemoteConfig | None) -> TypeGuard[RemoteConfig]:
     return remote_config is not None
+
+
+def _rev_parse(repo_dir: str, ref: str) -> str:
+    return (
+        subprocess.check_output(
+            ["git", "rev-parse", ref], cwd=repo_dir, stderr=subprocess.PIPE
+        )
+        .strip()
+        .decode()
+    )
 
 
 def _run_command(

--- a/devservices/utils/dependencies.py
+++ b/devservices/utils/dependencies.py
@@ -623,7 +623,7 @@ def _rev_parse(repo_dir: str, ref: str) -> str:
         .decode()
     )
     logger = logging.getLogger(LOGGER_NAME)
-    logger.debug("Parsed revision %s for %s", rev, ref)
+    logger.debug("Parsed revision %s for %s (%s)", rev, ref, repo_dir)
     return rev
 
 

--- a/devservices/utils/dependencies.py
+++ b/devservices/utils/dependencies.py
@@ -615,13 +615,16 @@ def _has_remote_config(remote_config: RemoteConfig | None) -> TypeGuard[RemoteCo
 
 
 def _rev_parse(repo_dir: str, ref: str) -> str:
-    return (
+    rev = (
         subprocess.check_output(
             ["git", "rev-parse", ref], cwd=repo_dir, stderr=subprocess.PIPE
         )
         .strip()
         .decode()
     )
+    logger = logging.getLogger(LOGGER_NAME)
+    logger.debug("Parsed revision %s for %s", rev, ref)
+    return rev
 
 
 def _run_command(

--- a/tests/utils/test_dependencies.py
+++ b/tests/utils/test_dependencies.py
@@ -845,6 +845,107 @@ def test_install_dependency_git_fetch_failure_with_retries(tmp_path: Path) -> No
         )
 
 
+def test_install_dependency_update_git_checkout_failure(tmp_path: Path) -> None:
+    with mock.patch(
+        "devservices.utils.dependencies.DEVSERVICES_DEPENDENCIES_CACHE_DIR",
+        str(tmp_path / "dependency-dir"),
+    ):
+        mock_git_repo = create_mock_git_repo("basic_repo", tmp_path / "test-repo")
+        mock_dependency = RemoteConfig(
+            repo_name="test-repo",
+            branch="main",
+            repo_link=f"file://{tmp_path / 'test-repo'}",
+        )
+
+        # Sanity check that the config file is not in the dependency directory (yet)
+        assert not (
+            tmp_path
+            / "dependency-dir"
+            / DEPENDENCY_CONFIG_VERSION
+            / "test-repo"
+            / DEVSERVICES_DIR_NAME
+            / CONFIG_FILE_NAME
+        ).exists()
+
+        install_dependency(mock_dependency)
+
+        assert (
+            tmp_path
+            / "dependency-dir"
+            / DEPENDENCY_CONFIG_VERSION
+            / "test-repo"
+            / DEVSERVICES_DIR_NAME
+            / CONFIG_FILE_NAME
+        ).exists()
+
+        # Append a new line to the config file in the mock repo and commit the change
+        with open(
+            mock_git_repo / DEVSERVICES_DIR_NAME / CONFIG_FILE_NAME,
+            mode="a",
+            encoding="utf-8",
+        ) as f:
+            f.write("\nedited: true")
+
+        run_git_command(["add", "."], cwd=mock_git_repo)
+        run_git_command(["commit", "-m", "Edit config file"], cwd=mock_git_repo)
+
+        with (
+            mock.patch(
+                "devservices.utils.dependencies._rev_parse",
+                side_effect=["123456", "654321"],
+            ),
+            mock.patch(
+                "devservices.utils.dependencies._run_command"
+            ) as mock_run_command,
+            mock.patch(
+                "devservices.utils.dependencies._is_valid_repo",
+                return_value=True,
+            ),
+            mock.patch("devservices.utils.dependencies.GitConfigManager.ensure_config"),
+            pytest.raises(DependencyError),
+        ):
+            mock_run_command.side_effect = [
+                subprocess.CompletedProcess(args="", returncode=0, stdout=""),
+                subprocess.CalledProcessError(returncode=1, cmd="test"),
+            ]
+            install_dependency(mock_dependency)
+
+        mock_run_command.assert_has_calls(
+            [
+                mock.call(
+                    [
+                        "git",
+                        "fetch",
+                        "origin",
+                        "main",
+                        "--filter=blob:none",
+                    ],
+                    cwd=str(
+                        tmp_path
+                        / "dependency-dir"
+                        / DEPENDENCY_CONFIG_VERSION
+                        / "test-repo"
+                    ),
+                    stdout=subprocess.DEVNULL,
+                ),
+                mock.call(
+                    [
+                        "git",
+                        "checkout",
+                        "-f",
+                        "FETCH_HEAD",
+                    ],
+                    cwd=str(
+                        tmp_path
+                        / "dependency-dir"
+                        / DEPENDENCY_CONFIG_VERSION
+                        / "test-repo"
+                    ),
+                ),
+            ]
+        )
+
+
 def test_install_dependency_basic(tmp_path: Path) -> None:
     with mock.patch(
         "devservices.utils.dependencies.DEVSERVICES_DEPENDENCIES_CACHE_DIR",


### PR DESCRIPTION
https://getsentry.atlassian.net/browse/DEVINFRA-598. Adding additional error handling to the core dependency logic. Fixed the `_run_command` function to now properly propagate the stderr which it did not do previously which should now give us more information into the failures we see. For now I opted not to add retries to anything besides fetch since fetch is by far the most likely to face transient errors, and retrying certain other commands can put us in a potentially problematic state.
More improvements to the core dependency logic, specifically around the git config are coming in another PR.