### PR TITLE
chore(healthchecks): Bump healthcheck timeout to 2 minutes

### DIFF
--- a/devservices/constants.py
+++ b/devservices/constants.py
@@ -37,5 +37,6 @@ DEVSERVICES_LATEST_VERSION_CACHE_FILE = os.path.join(
     DEVSERVICES_CACHE_DIR, "latest_version.txt"
 )
 DEVSERVICES_LATEST_VERSION_CACHE_TTL = timedelta(minutes=15)
-HEALTHCHECK_TIMEOUT = 45
+# Healthcheck timeout set to 2 minutes to account for slow healthchecks
+HEALTHCHECK_TIMEOUT = 120
 HEALTHCHECK_INTERVAL = 5

--- a/tests/commands/test_up.py
+++ b/tests/commands/test_up.py
@@ -556,7 +556,7 @@ def test_up_docker_compose_container_healthcheck_failed(
         assert "Starting clickhouse" in captured.out.strip()
         assert "Starting redis" in captured.out.strip()
         assert (
-            "Container container1 did not become healthy within 45 seconds."
+            "Container container1 did not become healthy within 120 seconds."
             in captured.out.strip()
         )
 


### PR DESCRIPTION
snuba healthcheck [here](https://github.com/getsentry/sentry/blob/7147e8e444c1319ad908d3a761eebcf2c3849604/src/sentry/runner/commands/devservices.py#L869) is 120 seconds, people are complaining about timeouts being exceeded so let's bump this