### PR TITLE
fix(dependencies): Exclude submodules from fetch

### DIFF
--- a/devservices/utils/dependencies.py
+++ b/devservices/utils/dependencies.py
@@ -472,7 +472,14 @@ def _update_dependency(
 
     try:
         _run_command_with_retries(
-            ["git", "fetch", "origin", dependency.branch, "--filter=blob:none"],
+            [
+                "git",
+                "fetch",
+                "origin",
+                dependency.branch,
+                "--filter=blob:none",
+                "--no-recurse-submodules",  # Avoid fetching submodules
+            ],
             cwd=dependency_repo_dir,
         )
     except subprocess.CalledProcessError as e:

--- a/tests/utils/test_dependencies.py
+++ b/tests/utils/test_dependencies.py
@@ -681,6 +681,7 @@ def test_install_dependency_git_fetch_transient_failure(tmp_path: Path) -> None:
                         "origin",
                         "main",
                         "--filter=blob:none",
+                        "--no-recurse-submodules",
                     ],
                     cwd=str(
                         tmp_path
@@ -697,6 +698,7 @@ def test_install_dependency_git_fetch_transient_failure(tmp_path: Path) -> None:
                         "origin",
                         "main",
                         "--filter=blob:none",
+                        "--no-recurse-submodules",
                     ],
                     cwd=str(
                         tmp_path
@@ -713,6 +715,7 @@ def test_install_dependency_git_fetch_transient_failure(tmp_path: Path) -> None:
                         "origin",
                         "main",
                         "--filter=blob:none",
+                        "--no-recurse-submodules",
                     ],
                     cwd=str(
                         tmp_path
@@ -800,6 +803,7 @@ def test_install_dependency_git_fetch_failure_with_retries(tmp_path: Path) -> No
                         "origin",
                         "main",
                         "--filter=blob:none",
+                        "--no-recurse-submodules",
                     ],
                     cwd=str(
                         tmp_path
@@ -816,6 +820,7 @@ def test_install_dependency_git_fetch_failure_with_retries(tmp_path: Path) -> No
                         "origin",
                         "main",
                         "--filter=blob:none",
+                        "--no-recurse-submodules",
                     ],
                     cwd=str(
                         tmp_path
@@ -832,6 +837,7 @@ def test_install_dependency_git_fetch_failure_with_retries(tmp_path: Path) -> No
                         "origin",
                         "main",
                         "--filter=blob:none",
+                        "--no-recurse-submodules",
                     ],
                     cwd=str(
                         tmp_path
@@ -919,6 +925,7 @@ def test_install_dependency_update_git_checkout_failure(tmp_path: Path) -> None:
                         "origin",
                         "main",
                         "--filter=blob:none",
+                        "--no-recurse-submodules",
                     ],
                     cwd=str(
                         tmp_path


### PR DESCRIPTION
https://getsentry.atlassian.net/browse/DEVINFRA-607
One of the most common sources of fetch failures is submodules, which we do not care about in the context of our dependency management. To mitigate these issues, we can just not recurse submodules all together when fetching.