### PR TITLE
fix(docker-compose): Allow docker compose verification logic to properly throw

### DIFF
--- a/devservices/utils/docker_compose.py
+++ b/devservices/utils/docker_compose.py
@@ -84,7 +84,10 @@ def install_docker_compose() -> None:
     # Verify the installation
     try:
         version = subprocess.run(
-            ["docker", "compose", "version", "--short"], capture_output=True, text=True
+            ["docker", "compose", "version", "--short"],
+            capture_output=True,
+            check=True,
+            text=True,
         ).stdout
     except Exception as e:
         raise DockerComposeInstallationError(

--- a/tests/utils/test_docker_compose.py
+++ b/tests/utils/test_docker_compose.py
@@ -192,7 +192,10 @@ def test_install_docker_compose_macos_arm64(
         os.path.expanduser("~/.docker/cli-plugins/docker-compose"),
     )
     mock_subprocess_run.assert_called_once_with(
-        ["docker", "compose", "version", "--short"], capture_output=True, text=True
+        ["docker", "compose", "version", "--short"],
+        capture_output=True,
+        check=True,
+        text=True,
     )
 
 
@@ -231,7 +234,10 @@ def test_install_docker_compose_linux_x86(
         os.path.expanduser("~/.docker/cli-plugins/docker-compose"),
     )
     mock_subprocess_run.assert_called_once_with(
-        ["docker", "compose", "version", "--short"], capture_output=True, text=True
+        ["docker", "compose", "version", "--short"],
+        capture_output=True,
+        check=True,
+        text=True,
     )
 
 


### PR DESCRIPTION
If `docker compose version --short` fails, exception is not thrown. This fixes that