### PR TITLE
chore(sentry): Fixing status for down when not running

### DIFF
--- a/devservices/commands/down.py
+++ b/devservices/commands/down.py
@@ -81,7 +81,7 @@ def down(args: Namespace) -> None:
     active_services = starting_services.union(started_services)
     if service.name not in active_services:
         console.warning(f"{service.name} is not running")
-        exit(0)
+        return  # Since exit(0) is captured as an internal_error by sentry
 
     active_starting_modes = state.get_active_modes_for_service(
         service.name, StateTables.STARTING_SERVICES


### PR DESCRIPTION
Currently, when running down when the service is not currently up, it is marked as an internal_error by Sentry despite exiting with a zero status code. To fix this, I updated the logic to return instead.