### PR TITLE
feat(sentry): Manually set status of transactions

### DIFF
--- a/devservices/commands/down.py
+++ b/devservices/commands/down.py
@@ -60,7 +60,7 @@ def down(args: Namespace) -> None:
     try:
         service = find_matching_service(service_name)
     except ConfigNotFoundError as e:
-        capture_exception(e)
+        capture_exception(e, level="info")
         console.failure(
             f"{str(e)}. Please specify a service (i.e. `devservices down sentry`) or run the command from a directory with a devservices configuration."
         )
@@ -148,7 +148,7 @@ def down(args: Namespace) -> None:
             try:
                 _down(service, remote_dependencies, list(mode_dependencies), status)
             except DockerComposeError as dce:
-                capture_exception(dce)
+                capture_exception(dce, level="info")
                 status.failure(f"Failed to stop {service.name}: {dce.stderr}")
                 exit(1)
         else:

--- a/devservices/commands/list_dependencies.py
+++ b/devservices/commands/list_dependencies.py
@@ -34,7 +34,7 @@ def list_dependencies(args: Namespace) -> None:
     try:
         service = find_matching_service(service_name)
     except ConfigNotFoundError as e:
-        capture_exception(e)
+        capture_exception(e, level="info")
         console.failure(
             f"{str(e)}. Please specify a service (i.e. `devservices list-dependencies sentry`) or run the command from a directory with a devservices configuration."
         )

--- a/devservices/commands/logs.py
+++ b/devservices/commands/logs.py
@@ -49,7 +49,7 @@ def logs(args: Namespace) -> None:
     try:
         service = find_matching_service(service_name)
     except ConfigNotFoundError as e:
-        capture_exception(e)
+        capture_exception(e, level="info")
         console.failure(
             f"{str(e)}. Please specify a service (i.e. `devservices logs sentry`) or run the command from a directory with a devservices configuration."
         )
@@ -86,7 +86,7 @@ def logs(args: Namespace) -> None:
     try:
         logs_output = _logs(service, remote_dependencies, mode_dependencies)
     except DockerComposeError as dce:
-        capture_exception(dce)
+        capture_exception(dce, level="info")
         console.failure(f"Failed to get logs for {service.name}: {dce.stderr}")
         exit(1)
     for log in logs_output:

--- a/devservices/commands/up.py
+++ b/devservices/commands/up.py
@@ -63,7 +63,7 @@ def up(args: Namespace) -> None:
     try:
         service = find_matching_service(service_name)
     except ConfigNotFoundError as e:
-        capture_exception(e)
+        capture_exception(e, level="info")
         console.failure(
             f"{str(e)}. Please specify a service (i.e. `devservices up sentry`) or run the command from a directory with a devservices configuration."
         )
@@ -110,7 +110,7 @@ def up(args: Namespace) -> None:
             mode_dependencies = modes[mode]
             _up(service, [mode], remote_dependencies, mode_dependencies, status)
         except DockerComposeError as dce:
-            capture_exception(dce)
+            capture_exception(dce, level="info")
             status.failure(f"Failed to start {service.name}: {dce.stderr}")
             exit(1)
     # TODO: We should factor in healthchecks here before marking service as running
@@ -154,7 +154,7 @@ def _up(
         service=service,
         remote_dependencies=sorted_remote_dependencies,
         current_env=current_env,
-        command="up",
+        command="upd",
         options=["-d", "--pull", "always"],
         service_config_file_path=service_config_file_path,
         mode_dependencies=mode_dependencies,

--- a/devservices/commands/up.py
+++ b/devservices/commands/up.py
@@ -154,7 +154,7 @@ def _up(
         service=service,
         remote_dependencies=sorted_remote_dependencies,
         current_env=current_env,
-        command="upd",
+        command="up",
         options=["-d", "--pull", "always"],
         service_config_file_path=service_config_file_path,
         mode_dependencies=mode_dependencies,

--- a/devservices/main.py
+++ b/devservices/main.py
@@ -47,27 +47,23 @@ current_version = metadata.version("devservices")
 error_trace_ids = set()
 
 
-"""Gets the trace_id from the errors we care about.
-
-This function is used as a before_send callback for Sentry to track error trace IDs.
-It adds the trace_id to error_trace_ids set for non-info level events.
-"""
-
-
 def before_send_error(event: Event, hint: Hint) -> Event:
+    """Gets the trace_id from the errors we care about.
+
+    This function is used as a before_send callback for Sentry to track error trace IDs.
+    It adds the trace_id to error_trace_ids set for non-info level events.
+    """
     if event["level"] != "info":
         error_trace_ids.add(event["contexts"]["trace"]["trace_id"])
     return event
 
 
-"""Manually sets the status of a transaction.
-
-This function is used as a before_send_transaction callback for Sentry to mark transaction status
-as unknown if they don't correspond to errors we care about.
-"""
-
-
 def before_send_transaction(event: Event, hint: Hint) -> Event:
+    """Manually sets the status of a transaction.
+
+    This function is used as a before_send_transaction callback for Sentry to mark transaction status
+    as unknown if they don't correspond to errors we care about.
+    """
     if event["contexts"]["trace"]["trace_id"] not in error_trace_ids:
         event["contexts"]["trace"]["status"] = "unknown"
     return event


### PR DESCRIPTION
For transactions that do not have a trace that is tied to an error that has a higher level than "info", we manually set the status to unknown