### PR TITLE
ref(dependency-graph): Adding more context to the dependency graph

### DIFF
--- a/devservices/commands/down.py
+++ b/devservices/commands/down.py
@@ -22,6 +22,8 @@ from devservices.exceptions import ServiceNotFoundError
 from devservices.utils.console import Console
 from devservices.utils.console import Status
 from devservices.utils.dependencies import construct_dependency_graph
+from devservices.utils.dependencies import DependencyNode
+from devservices.utils.dependencies import DependencyType
 from devservices.utils.dependencies import get_non_shared_remote_dependencies
 from devservices.utils.dependencies import install_and_verify_dependencies
 from devservices.utils.dependencies import InstalledRemoteDependency
@@ -234,7 +236,10 @@ def _get_dependent_service(
         )
         # If the service we are trying to bring down is in the dependency graph of another service,
         # we should not bring it down
-        if service.name in dependency_graph.graph:
+        if (
+            DependencyNode(name=service.name, dependency_type=DependencyType.SERVICE)
+            in dependency_graph.graph
+        ):
             return other_started_service
 
     return None

--- a/devservices/commands/up.py
+++ b/devservices/commands/up.py
@@ -24,6 +24,8 @@ from devservices.exceptions import ServiceNotFoundError
 from devservices.utils.console import Console
 from devservices.utils.console import Status
 from devservices.utils.dependencies import construct_dependency_graph
+from devservices.utils.dependencies import DependencyNode
+from devservices.utils.dependencies import DependencyType
 from devservices.utils.dependencies import install_and_verify_dependencies
 from devservices.utils.dependencies import InstalledRemoteDependency
 from devservices.utils.docker import check_all_containers_healthy
@@ -169,7 +171,12 @@ def _up(
     dependency_graph = construct_dependency_graph(service, modes=modes)
     starting_order = dependency_graph.get_starting_order()
     sorted_remote_dependencies = sorted(
-        remote_dependencies, key=lambda dep: starting_order.index(dep.service_name)
+        remote_dependencies,
+        key=lambda dep: starting_order.index(
+            DependencyNode(
+                name=dep.service_name, dependency_type=DependencyType.SERVICE
+            )
+        ),
     )
     # Pull all images in parallel
     status.info("Pulling images")

--- a/devservices/utils/dependencies.py
+++ b/devservices/utils/dependencies.py
@@ -10,6 +10,7 @@ from collections import deque
 from concurrent.futures import as_completed
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
+from enum import Enum
 from typing import TextIO
 from typing import TypeGuard
 
@@ -53,51 +54,75 @@ RELEVANT_GIT_CONFIG_KEYS = [
 ]
 
 
+class DependencyType(str, Enum):
+    SERVICE = "service"
+    COMPOSE = "compose"
+
+
+@dataclass(frozen=True, eq=True)
+class DependencyNode:
+    name: str
+    dependency_type: DependencyType
+
+    def __str__(self) -> str:
+        return self.name
+
+    def qualified_name(self) -> str:
+        return f"{self.dependency_type.value}:{self.name}"
+
+
 class DependencyGraph:
     def __init__(self) -> None:
-        self.graph: dict[str, set[str]] = dict()
+        self.graph: dict[DependencyNode, set[DependencyNode]] = dict()
 
-    def add_dependency(self, service_name: str) -> None:
-        if service_name not in self.graph:
-            self.graph[service_name] = set()
+    def get_node(self, name: str, kind: DependencyType) -> DependencyNode:
+        node = DependencyNode(dependency_type=kind, name=name)
+        if node not in self.graph:
+            raise ValueError(f"Node {node.qualified_name} not found in the graph")
+        return node
 
-    def add_edge(self, service_name: str, dependency_name: str) -> None:
+    def add_node(self, node: DependencyNode) -> None:
+        if node not in self.graph:
+            self.graph[node] = set()
+
+    def add_edge(self, from_node: DependencyNode, to_node: DependencyNode) -> None:
         # TODO: We should rename services that depend on themselves
-        if service_name == dependency_name:
-            return
-        if service_name not in self.graph:
-            self.add_dependency(service_name)
-        if dependency_name not in self.graph:
-            self.add_dependency(dependency_name)
+        if from_node == to_node:
+            if from_node.dependency_type == to_node.dependency_type:
+                return
+        if from_node not in self.graph:
+            self.add_node(from_node)
+        if to_node not in self.graph:
+            self.add_node(to_node)
 
         # TODO: Should we check for cycles here?
 
-        self.graph[service_name].add(dependency_name)
+        self.graph[from_node].add(to_node)
 
-    def topological_sort(self) -> list[str]:
+    def topological_sort(self) -> list[DependencyNode]:
         in_degree = {service_name: 0 for service_name in self.graph}
 
-        for service_name in self.graph.keys():
-            for dependency in self.graph[service_name]:
-                in_degree[dependency] += 1
+        for service_node in self.graph.keys():
+            for dependency_node in self.graph[service_node]:
+                in_degree[dependency_node] += 1
 
         queue = deque(
             [
-                service_name
-                for service_name in self.graph
-                if in_degree[service_name] == 0
+                dependency_node
+                for dependency_node in self.graph
+                if in_degree[dependency_node] == 0
             ]
         )
         topological_order = list()
 
         while queue:
-            service_name = queue.popleft()
-            topological_order.append(service_name)
+            service_node = queue.popleft()
+            topological_order.append(service_node)
 
-            for dependency in self.graph[service_name]:
-                in_degree[dependency] -= 1
-                if in_degree[dependency] == 0:
-                    queue.append(dependency)
+            for dependency_node in self.graph[service_node]:
+                in_degree[dependency_node] -= 1
+                if in_degree[dependency_node] == 0:
+                    queue.append(dependency_node)
 
         if len(topological_order) != len(self.graph):
             # TODO: Add a better exception
@@ -105,7 +130,7 @@ class DependencyGraph:
 
         return topological_order
 
-    def get_starting_order(self) -> list[str]:
+    def get_starting_order(self) -> list[DependencyNode]:
         return list(reversed(self.topological_sort()))
 
 
@@ -729,7 +754,18 @@ def construct_dependency_graph(service: Service, modes: list[str]) -> Dependency
             # Skip the dependency if it's not in the modes (since it may not be installed and we don't care about it)
             if dependency_name not in service_mode_dependencies:
                 continue
-            dependency_graph.add_edge(service_config.service_name, dependency_name)
+            dependency_graph.add_edge(
+                DependencyNode(
+                    name=service_config.service_name,
+                    dependency_type=DependencyType.SERVICE,
+                ),
+                DependencyNode(
+                    name=dependency_name,
+                    dependency_type=DependencyType.SERVICE
+                    if _has_remote_config(dependency.remote)
+                    else DependencyType.COMPOSE,
+                ),
+            )
             if _has_remote_config(dependency.remote):
                 dependency_config = get_remote_dependency_config(dependency.remote)
                 _construct_dependency_graph(dependency_config, [dependency.remote.mode])


### PR DESCRIPTION
This change adds context about whether a given node in the dependency graph is a docker compose service (leaf) or a devservices service. This enables us to avoid cycles when we have docker compose services with the same name as the devservices service which is a common thing we see such as with snuba and it's container.
https://linear.app/getsentry/issue/DI-661/add-more-context-to-dependency-graph
This is required to enable the improvements we are looking to make to the status command: https://linear.app/getsentry/issue/DI-647/rework-status-command.