### PR TITLE
ref(status): Revamp status command

### DIFF
--- a/devservices/commands/status.py
+++ b/devservices/commands/status.py
@@ -118,13 +118,13 @@ def get_status_for_service(service: Service) -> str:
 
     modes = service.config.modes
 
-    starting_modes = state.get_active_modes_for_service(
-        service.name, StateTables.STARTING_SERVICES
+    starting_modes = set(
+        state.get_active_modes_for_service(service.name, StateTables.STARTING_SERVICES)
     )
-    started_modes = state.get_active_modes_for_service(
-        service.name, StateTables.STARTED_SERVICES
+    started_modes = set(
+        state.get_active_modes_for_service(service.name, StateTables.STARTED_SERVICES)
     )
-    active_modes = starting_modes or started_modes
+    active_modes = starting_modes.union(started_modes)
     mode_dependencies = set()
     for active_mode in active_modes:
         active_mode_dependencies = modes.get(active_mode, [])
@@ -132,7 +132,7 @@ def get_status_for_service(service: Service) -> str:
 
     remote_dependencies = install_and_verify_dependencies(service)
 
-    dependency_graph = construct_dependency_graph(service, active_modes)
+    dependency_graph = construct_dependency_graph(service, list(active_modes))
 
     status_json_results = get_status_json_results(
         service, remote_dependencies, list(mode_dependencies)

--- a/devservices/commands/status.py
+++ b/devservices/commands/status.py
@@ -8,6 +8,7 @@ from argparse import _SubParsersAction
 from argparse import ArgumentParser
 from argparse import Namespace
 from collections import namedtuple
+from typing import TypedDict
 
 from sentry_sdk import capture_exception
 
@@ -22,17 +23,40 @@ from devservices.exceptions import DependencyError
 from devservices.exceptions import DockerComposeError
 from devservices.exceptions import ServiceNotFoundError
 from devservices.utils.console import Console
+from devservices.utils.dependencies import construct_dependency_graph
+from devservices.utils.dependencies import DependencyGraph
+from devservices.utils.dependencies import DependencyNode
+from devservices.utils.dependencies import DependencyType
 from devservices.utils.dependencies import install_and_verify_dependencies
 from devservices.utils.dependencies import InstalledRemoteDependency
 from devservices.utils.docker_compose import get_docker_compose_commands_to_run
 from devservices.utils.docker_compose import run_cmd
 from devservices.utils.services import find_matching_service
 from devservices.utils.services import Service
+from devservices.utils.state import ServiceRuntime
+from devservices.utils.state import State
+from devservices.utils.state import StateTables
 
-LINE_LENGTH = 40
+BASE_INDENTATION = "  "
 
 
 ServiceStatus = namedtuple("ServiceStatus", ["name", "formatted_output"])
+
+
+class ServiceStatusOutput(TypedDict):
+    Service: str
+    Name: str
+    State: str
+    Health: str
+    RunningFor: str
+    Publishers: list[Ports]
+
+
+class Ports(TypedDict):
+    URL: str
+    PublishedPort: int
+    TargetPort: int
+    Protocol: str
 
 
 def add_parser(subparsers: _SubParsersAction[ArgumentParser]) -> None:
@@ -44,41 +68,6 @@ def add_parser(subparsers: _SubParsersAction[ArgumentParser]) -> None:
         default=None,
     )
     parser.set_defaults(func=status)
-
-
-def format_status_output(service_status_json: str) -> list[ServiceStatus]:
-    # Docker compose ps is line delimited json, so this constructs this into an array we can use
-    service_statuses = service_status_json.split("\n")[:-1]
-    outputs = []
-    for service_status in service_statuses:
-        output = []
-        service = json.loads(service_status)
-        name = service["Service"]
-        state = service["State"]
-        container_name = service["Name"]
-        health = service.get("Health", "N/A")
-        ports = service.get("Publishers", [])
-        running_for = service.get("RunningFor", "N/A")
-
-        output.append(f"{name}")
-        output.append(f"Container: {container_name}")
-        output.append(f"Status: {state}")
-        output.append(f"Health: {health}")
-        output.append(f"Uptime: {running_for}")
-
-        if ports:
-            output.append("Ports:")
-            for port in ports:
-                output.append(
-                    f"  {port['URL']}:{port['PublishedPort']} -> {port['TargetPort']}/{port['Protocol']}"
-                )
-        else:
-            output.append("No ports exposed")
-
-        output.append("")  # Empty line for readability
-        outputs.append(ServiceStatus(name=name, formatted_output="\n".join(output)))
-
-    return outputs
 
 
 def status(args: Namespace) -> None:
@@ -101,46 +90,62 @@ def status(args: Namespace) -> None:
         console.failure(str(e))
         exit(1)
 
-    modes = service.config.modes
-    # TODO: allow custom modes to be used
-    mode_to_view = "default"
-    mode_dependencies = modes[mode_to_view]
+    state = State()
+    starting_services = set(state.get_service_entries(StateTables.STARTING_SERVICES))
+    started_services = set(state.get_service_entries(StateTables.STARTED_SERVICES))
+    active_services = starting_services.union(started_services)
+    if service.name not in active_services:
+        console.warning(f"{service.name} is not running standalone")
+        return  # Since exit(0) is captured as an internal_error by sentry
 
     try:
-        remote_dependencies = install_and_verify_dependencies(service)
+        status_tree = get_status_for_service(service)
     except DependencyError as de:
         capture_exception(de)
         console.failure(
             f"{str(de)}. If this error persists, try running `devservices purge`"
         )
         exit(1)
-    try:
-        status_json_results = _status(service, remote_dependencies, mode_dependencies)
     except DockerComposeError as dce:
         capture_exception(dce)
         console.failure(f"Failed to get status for {service.name}: {dce.stderr}")
         exit(1)
-
-    # Filter out empty stdout to help us determine if the service is running
-    status_json_results = [
-        status_json for status_json in status_json_results if status_json.stdout
-    ]
-    if len(status_json_results) == 0:
-        console.warning(f"{service.name} is not running")
-        return
-    output = f"Service: {service.name}\n\n"
-    output += "=" * LINE_LENGTH + "\n"
-    formatted_status_outputs = []
-    for status_json in status_json_results:
-        formatted_status_outputs.extend(format_status_output(status_json.stdout))
-    formatted_status_outputs.sort(key=lambda x: x.name)
-    for formatted_status_output in formatted_status_outputs:
-        output += formatted_status_output[1]
-        output += "-" * LINE_LENGTH + "\n"
-    console.info(output)
+    console.info(status_tree)
 
 
-def _status(
+def get_status_for_service(service: Service) -> str:
+    state = State()
+
+    modes = service.config.modes
+
+    starting_modes = state.get_active_modes_for_service(
+        service.name, StateTables.STARTING_SERVICES
+    )
+    started_modes = state.get_active_modes_for_service(
+        service.name, StateTables.STARTED_SERVICES
+    )
+    active_modes = starting_modes or started_modes
+    mode_dependencies = set()
+    for active_mode in active_modes:
+        active_mode_dependencies = modes.get(active_mode, [])
+        mode_dependencies.update(active_mode_dependencies)
+
+    remote_dependencies = install_and_verify_dependencies(service)
+
+    dependency_graph = construct_dependency_graph(service, active_modes)
+
+    status_json_results = get_status_json_results(
+        service, remote_dependencies, list(mode_dependencies)
+    )
+
+    docker_compose_service_to_status = parse_docker_compose_status(status_json_results)
+    status_tree = generate_service_status_tree(
+        service.name, dependency_graph, docker_compose_service_to_status
+    )
+    return status_tree
+
+
+def get_status_json_results(
     service: Service,
     remote_dependencies: set[InstalledRemoteDependency],
     mode_dependencies: list[str],
@@ -178,3 +183,187 @@ def _status(
             cmd_outputs.append(future.result())
 
     return cmd_outputs
+
+
+def generate_service_status_tree(
+    service_name: str,
+    dependency_graph: DependencyGraph,
+    docker_compose_service_to_status: dict[str, ServiceStatusOutput],
+    indentation: str = "",
+) -> str:
+    output = []
+    state = State()
+    services_with_local_runtime = state.get_services_by_runtime(ServiceRuntime.LOCAL)
+
+    dependencies = dependency_graph.graph[
+        DependencyNode(name=service_name, dependency_type=DependencyType.SERVICE)
+    ]
+
+    # Using indentation == "" to check if the service is the root service (hacky, but works) since the root service may not be in the services_with_local_runtime set
+    runtime = (
+        "local"
+        if service_name in services_with_local_runtime or indentation == ""
+        else "containerized"
+    )
+
+    output = [
+        f"{indentation}\033[1m{service_name}\033[0m:",
+        f"{indentation}{BASE_INDENTATION}Type: service",
+        f"{indentation}{BASE_INDENTATION}Runtime: {runtime}",
+    ]
+
+    for dependency in sorted(
+        dependencies, key=lambda d: (d.dependency_type.value, d.name)
+    ):
+        if dependency.name in services_with_local_runtime:
+            output.append(
+                process_service_with_local_runtime(
+                    dependency,
+                    indentation + BASE_INDENTATION,
+                )
+            )
+        else:
+            output.append(
+                process_service_with_containerized_runtime(
+                    dependency,
+                    docker_compose_service_to_status,
+                    indentation + BASE_INDENTATION,
+                    dependency_graph,
+                )
+            )
+    return "\n".join(output)
+
+
+def process_service_with_local_runtime(
+    dependency: DependencyNode,
+    indentation: str,
+) -> str:
+    output = []
+    state = State()
+    starting_services = set(state.get_service_entries(StateTables.STARTING_SERVICES))
+    started_services = set(state.get_service_entries(StateTables.STARTED_SERVICES))
+
+    if dependency.name in started_services:
+        return handle_started_service(dependency, indentation)
+    elif dependency.name in starting_services:
+        output.append(f"{indentation}\033[1m{dependency.name}\033[0m:")
+        output.append(f"{indentation}{BASE_INDENTATION}Type: service")
+        output.append(f"{indentation}{BASE_INDENTATION}Status: starting")
+        output.append(f"{indentation}{BASE_INDENTATION}Runtime: local")
+    else:
+        output.append(f"{indentation}\033[1m{dependency.name}\033[0m:")
+        output.append(f"{indentation}{BASE_INDENTATION}Type: service")
+        output.append(f"{indentation}{BASE_INDENTATION}Status: N/A")
+        output.append(f"{indentation}{BASE_INDENTATION}Runtime: local")
+    return "\n".join(output)
+
+
+def process_service_with_containerized_runtime(
+    dependency: DependencyNode,
+    docker_compose_service_to_status: dict[str, ServiceStatusOutput],
+    indentation: str,
+    dependency_graph: DependencyGraph,
+) -> str:
+    if len(dependency_graph.graph[dependency]) > 0:
+        return generate_service_status_tree(
+            dependency.name,
+            dependency_graph,
+            docker_compose_service_to_status,
+            indentation,
+        )
+    else:
+        return generate_service_status_details(
+            dependency, docker_compose_service_to_status, indentation
+        )
+
+
+def parse_docker_compose_status(
+    status_json_results: list[subprocess.CompletedProcess[str]],
+) -> dict[str, ServiceStatusOutput]:
+    """Parse the JSON output from docker-compose status command."""
+    docker_compose_service_to_status: dict[str, ServiceStatusOutput] = {}
+    for status_json in status_json_results:
+        if not status_json.stdout:
+            continue
+        docker_compose_service_status_output = status_json.stdout.split("\n")[:-1]
+        for docker_compose_service_status in docker_compose_service_status_output:
+            docker_compose_service_status_json = json.loads(
+                docker_compose_service_status
+            )
+            compose_service = docker_compose_service_status_json["Service"]
+            docker_compose_service_to_status[
+                compose_service
+            ] = docker_compose_service_status_json
+
+    return docker_compose_service_to_status
+
+
+def generate_service_status_details(
+    dependency: DependencyNode,
+    docker_compose_service_to_status: dict[str, ServiceStatusOutput],
+    indentation: str,
+) -> str:
+    output = [f"{indentation}\033[1m{dependency.name}\033[0m:"]
+
+    if dependency.name not in docker_compose_service_to_status:
+        return "\n".join(
+            [
+                *output,
+                f"{indentation}{BASE_INDENTATION}Type: container",
+                f"{indentation}{BASE_INDENTATION}Status: N/A",
+            ]
+        )
+
+    service_status = docker_compose_service_to_status[dependency.name]
+    details = [
+        "Type: container",
+        f"Status: {service_status.get('State', 'N/A')}",
+        f"Health: {format_health(service_status.get('Health', 'N/A'))}",
+        f"Container: {service_status.get('Name', 'N/A')}",
+        f"Uptime: {service_status.get('RunningFor', 'N/A')}",
+    ]
+
+    output.extend(f"{indentation}{BASE_INDENTATION}{detail}" for detail in details)
+
+    if service_ports := service_status.get("Publishers", []):
+        output.append(f"{indentation}{BASE_INDENTATION}Ports:")
+        for service_port in service_ports:
+            output.append(
+                f"{indentation}{BASE_INDENTATION}{BASE_INDENTATION}{service_port['URL']}:{service_port['PublishedPort']} -> {service_port['TargetPort']}/{service_port['Protocol']}"
+            )
+
+    return "\n".join(output)
+
+
+def handle_started_service(dependency: DependencyNode, indentation: str) -> str:
+    try:
+        service_with_local_runtime = find_matching_service(dependency.name)
+    except (ConfigError, ServiceNotFoundError) as e:
+        capture_exception(e)
+        return "\n".join(
+            [
+                f"{indentation}\033[1m{dependency.name}\033[0m:",
+                f"{indentation}{BASE_INDENTATION}Type: service",
+                f"{indentation}{BASE_INDENTATION}Status: N/A",
+                f"{indentation}{BASE_INDENTATION}Runtime: local",
+            ]
+        )
+    service_output = get_status_for_service(service_with_local_runtime)
+    return "\n".join(
+        [
+            f"{indentation}{BASE_INDENTATION}{line}"
+            for line in service_output.splitlines()
+        ],
+    )
+
+
+def format_health(health: str) -> str:
+    """Format the health status for display."""
+    color = (
+        "\033[32m"
+        if health.lower() == "healthy"
+        else "\033[91m"
+        if health.lower() == "unhealthy"
+        else "\033[93m"
+    )
+    return f"{color}{health}\033[0m"

--- a/devservices/commands/status.py
+++ b/devservices/commands/status.py
@@ -95,7 +95,7 @@ def status(args: Namespace) -> None:
     started_services = set(state.get_service_entries(StateTables.STARTED_SERVICES))
     active_services = starting_services.union(started_services)
     if service.name not in active_services:
-        console.warning(f"{service.name} is not running standalone")
+        console.warning(f"Status unavailable. {service.name} is not running standalone")
         return  # Since exit(0) is captured as an internal_error by sentry
 
     try:

--- a/devservices/commands/status.py
+++ b/devservices/commands/status.py
@@ -12,6 +12,7 @@ from typing import TypedDict
 
 from sentry_sdk import capture_exception
 
+from devservices.constants import Color
 from devservices.constants import CONFIG_FILE_NAME
 from devservices.constants import DEPENDENCY_CONFIG_VERSION
 from devservices.constants import DEVSERVICES_DEPENDENCIES_CACHE_DIR
@@ -207,7 +208,7 @@ def generate_service_status_tree(
     )
 
     output = [
-        f"{indentation}\033[1m{service_name}\033[0m:",
+        f"{indentation}{Color.BOLD}{service_name}{Color.RESET}:",
         f"{indentation}{BASE_INDENTATION}Type: service",
         f"{indentation}{BASE_INDENTATION}Runtime: {runtime}",
     ]
@@ -246,12 +247,12 @@ def process_service_with_local_runtime(
     if dependency.name in started_services:
         return handle_started_service(dependency, indentation)
     elif dependency.name in starting_services:
-        output.append(f"{indentation}\033[1m{dependency.name}\033[0m:")
+        output.append(f"{indentation}{Color.BOLD}{dependency.name}{Color.RESET}:")
         output.append(f"{indentation}{BASE_INDENTATION}Type: service")
         output.append(f"{indentation}{BASE_INDENTATION}Status: starting")
         output.append(f"{indentation}{BASE_INDENTATION}Runtime: local")
     else:
-        output.append(f"{indentation}\033[1m{dependency.name}\033[0m:")
+        output.append(f"{indentation}{Color.BOLD}{dependency.name}{Color.RESET}:")
         output.append(f"{indentation}{BASE_INDENTATION}Type: service")
         output.append(f"{indentation}{BASE_INDENTATION}Status: N/A")
         output.append(f"{indentation}{BASE_INDENTATION}Runtime: local")
@@ -303,7 +304,7 @@ def generate_service_status_details(
     docker_compose_service_to_status: dict[str, ServiceStatusOutput],
     indentation: str,
 ) -> str:
-    output = [f"{indentation}\033[1m{dependency.name}\033[0m:"]
+    output = [f"{indentation}{Color.BOLD}{dependency.name}{Color.RESET}:"]
 
     if dependency.name not in docker_compose_service_to_status:
         return "\n".join(
@@ -342,7 +343,7 @@ def handle_started_service(dependency: DependencyNode, indentation: str) -> str:
         capture_exception(e)
         return "\n".join(
             [
-                f"{indentation}\033[1m{dependency.name}\033[0m:",
+                f"{indentation}{Color.BOLD}{dependency.name}{Color.RESET}:",
                 f"{indentation}{BASE_INDENTATION}Type: service",
                 f"{indentation}{BASE_INDENTATION}Status: N/A",
                 f"{indentation}{BASE_INDENTATION}Runtime: local",
@@ -360,10 +361,10 @@ def handle_started_service(dependency: DependencyNode, indentation: str) -> str:
 def format_health(health: str) -> str:
     """Format the health status for display."""
     color = (
-        "\033[32m"
+        Color.GREEN
         if health.lower() == "healthy"
-        else "\033[91m"
+        else Color.RED
         if health.lower() == "unhealthy"
-        else "\033[93m"
+        else Color.YELLOW
     )
-    return f"{color}{health}\033[0m"
+    return f"{color}{health}{Color.RESET}"

--- a/devservices/constants.py
+++ b/devservices/constants.py
@@ -3,6 +3,18 @@ from __future__ import annotations
 import os
 from datetime import timedelta
 
+
+class Color:
+    RED = "\033[0;31m"
+    GREEN = "\033[0;32m"
+    YELLOW = "\033[0;33m"
+    BLUE = "\033[0;34m"
+    BOLD = "\033[1m"
+    UNDERLINE = "\033[4m"
+    NEGATIVE = "\033[7m"
+    RESET = "\033[0m"
+
+
 MINIMUM_DOCKER_COMPOSE_VERSION = "2.29.7"
 DEVSERVICES_DIR_NAME = "devservices"
 CONFIG_FILE_NAME = "config.yml"

--- a/devservices/utils/console.py
+++ b/devservices/utils/console.py
@@ -7,19 +7,10 @@ import time
 from collections.abc import Callable
 from types import TracebackType
 
+from devservices.constants import Color
+
 
 ANIMATION_FRAMES = ("⠟", "⠯", "⠷", "⠾", "⠽", "⠻")
-
-
-class Color:
-    RED = "\033[0;31m"
-    GREEN = "\033[0;32m"
-    YELLOW = "\033[0;33m"
-    BLUE = "\033[0;34m"
-    BOLD = "\033[1m"
-    UNDERLINE = "\033[4m"
-    NEGATIVE = "\033[7m"
-    RESET = "\033[0m"
 
 
 class Console:

--- a/tests/commands/test_status.py
+++ b/tests/commands/test_status.py
@@ -165,7 +165,7 @@ def test_generate_service_status_details() -> None:
             "RunningFor": "2 days ago",
             "Publishers": [
                 {
-                    "URL": "http://localhost",
+                    "URL": "127.0.0.1",
                     "PublishedPort": 8080,
                     "TargetPort": 8080,
                     "Protocol": "tcp",
@@ -184,7 +184,7 @@ def test_generate_service_status_details() -> None:
         "  Container: test-container\n"
         "  Uptime: 2 days ago\n"
         "  Ports:\n"
-        "    http://localhost:8080 -> 8080/tcp"
+        "    127.0.0.1:8080 -> 8080/tcp"
     )
 
 
@@ -227,13 +227,13 @@ def test_generate_service_status_tree_no_child_service(
                 "RunningFor": "2 days ago",
                 "Publishers": [
                     {
-                        "URL": "http://localhost",
+                        "URL": "127.0.0.1",
                         "PublishedPort": 8080,
                         "TargetPort": 8080,
                         "Protocol": "tcp",
                     },
                     {
-                        "URL": "http://localhost",
+                        "URL": "127.0.0.1",
                         "PublishedPort": 8081,
                         "TargetPort": 8081,
                         "Protocol": "tcp",
@@ -258,8 +258,8 @@ def test_generate_service_status_tree_no_child_service(
             "    Container: parent-container\n"
             "    Uptime: 2 days ago\n"
             "    Ports:\n"
-            "      http://localhost:8080 -> 8080/tcp\n"
-            "      http://localhost:8081 -> 8081/tcp"
+            "      127.0.0.1:8080 -> 8080/tcp\n"
+            "      127.0.0.1:8081 -> 8081/tcp"
         )
 
 
@@ -296,13 +296,13 @@ def test_generate_service_status_tree_with_child_service(
                 "RunningFor": "2 days ago",
                 "Publishers": [
                     {
-                        "URL": "http://localhost",
+                        "URL": "127.0.0.1",
                         "PublishedPort": 8080,
                         "TargetPort": 8080,
                         "Protocol": "tcp",
                     },
                     {
-                        "URL": "http://localhost",
+                        "URL": "127.0.0.1",
                         "PublishedPort": 8081,
                         "TargetPort": 8081,
                         "Protocol": "tcp",
@@ -317,7 +317,7 @@ def test_generate_service_status_tree_with_child_service(
                 "RunningFor": "2 days ago",
                 "Publishers": [
                     {
-                        "URL": "http://localhost",
+                        "URL": "127.0.0.1",
                         "PublishedPort": 8082,
                         "TargetPort": 8082,
                         "Protocol": "tcp",
@@ -342,8 +342,8 @@ def test_generate_service_status_tree_with_child_service(
             "    Container: parent-container\n"
             "    Uptime: 2 days ago\n"
             "    Ports:\n"
-            "      http://localhost:8080 -> 8080/tcp\n"
-            "      http://localhost:8081 -> 8081/tcp\n"
+            "      127.0.0.1:8080 -> 8080/tcp\n"
+            "      127.0.0.1:8081 -> 8081/tcp\n"
             f"  {Color.BOLD}child-service{Color.RESET}:\n"
             "    Type: service\n"
             "    Runtime: containerized\n"
@@ -354,7 +354,7 @@ def test_generate_service_status_tree_with_child_service(
             "      Container: child-container\n"
             "      Uptime: 2 days ago\n"
             "      Ports:\n"
-            "        http://localhost:8082 -> 8082/tcp"
+            "        127.0.0.1:8082 -> 8082/tcp"
         )
 
 
@@ -402,7 +402,7 @@ def test_generate_service_status_tree_with_nested_child_services(
                 "RunningFor": "1 days ago",
                 "Publishers": [
                     {
-                        "URL": "http://localhost",
+                        "URL": "127.0.0.1",
                         "PublishedPort": 8080,
                         "TargetPort": 8080,
                         "Protocol": "tcp",
@@ -417,7 +417,7 @@ def test_generate_service_status_tree_with_nested_child_services(
                 "RunningFor": "3 days ago",
                 "Publishers": [
                     {
-                        "URL": "http://localhost",
+                        "URL": "127.0.0.1",
                         "PublishedPort": 8081,
                         "TargetPort": 8081,
                         "Protocol": "tcp",
@@ -432,7 +432,7 @@ def test_generate_service_status_tree_with_nested_child_services(
                 "RunningFor": "2 days ago",
                 "Publishers": [
                     {
-                        "URL": "http://localhost",
+                        "URL": "127.0.0.1",
                         "PublishedPort": 8082,
                         "TargetPort": 8082,
                         "Protocol": "tcp",
@@ -457,7 +457,7 @@ def test_generate_service_status_tree_with_nested_child_services(
             "    Container: grandparent-container\n"
             "    Uptime: 1 days ago\n"
             "    Ports:\n"
-            "      http://localhost:8080 -> 8080/tcp\n"
+            "      127.0.0.1:8080 -> 8080/tcp\n"
             f"  {Color.BOLD}parent-service{Color.RESET}:\n"
             "    Type: service\n"
             "    Runtime: containerized\n"
@@ -468,7 +468,7 @@ def test_generate_service_status_tree_with_nested_child_services(
             "      Container: parent-container\n"
             "      Uptime: 3 days ago\n"
             "      Ports:\n"
-            "        http://localhost:8081 -> 8081/tcp\n"
+            "        127.0.0.1:8081 -> 8081/tcp\n"
             f"    {Color.BOLD}child-service{Color.RESET}:\n"
             "      Type: service\n"
             "      Runtime: containerized\n"
@@ -479,7 +479,7 @@ def test_generate_service_status_tree_with_nested_child_services(
             "        Container: child-container\n"
             "        Uptime: 2 days ago\n"
             "        Ports:\n"
-            "          http://localhost:8082 -> 8082/tcp"
+            "          127.0.0.1:8082 -> 8082/tcp"
         )
 
 
@@ -489,7 +489,7 @@ def test_generate_service_status_tree_with_nested_child_services(
         subprocess.CompletedProcess(
             args=[],
             returncode=0,
-            stdout='{"Project": "test-service", "Service": "clickhouse", "State": "running", "Health": "healthy", "Name": "test-service-clickhouse-1", "RunningFor": "1 days ago", "Publishers": [{"URL": "http://localhost", "PublishedPort": 8080, "TargetPort": 8080, "Protocol": "tcp"}]}\n{"Project": "test-service", "Service": "redis", "State": "running", "Health": "healthy", "Name": "test-service-redis-1", "RunningFor": "1 days ago", "Publishers": [{"URL": "http://localhost", "PublishedPort": 8081, "TargetPort": 8081, "Protocol": "tcp"}]}\n',
+            stdout='{"Project": "test-service", "Service": "clickhouse", "State": "running", "Health": "healthy", "Name": "test-service-clickhouse-1", "RunningFor": "1 days ago", "Publishers": [{"URL": "127.0.0.1", "PublishedPort": 8080, "TargetPort": 8080, "Protocol": "tcp"}]}\n{"Project": "test-service", "Service": "redis", "State": "running", "Health": "healthy", "Name": "test-service-redis-1", "RunningFor": "1 days ago", "Publishers": [{"URL": "127.0.0.1", "PublishedPort": 8081, "TargetPort": 8081, "Protocol": "tcp"}]}\n',
             stderr="",
         ),
     ],
@@ -568,7 +568,7 @@ def test_handle_started_service(
             "        Container: test-service-clickhouse-1\n"
             "        Uptime: 1 days ago\n"
             "        Ports:\n"
-            "          http://localhost:8080 -> 8080/tcp\n"
+            "          127.0.0.1:8080 -> 8080/tcp\n"
             f"      {Color.BOLD}redis{Color.RESET}:\n"
             "        Type: container\n"
             "        Status: running\n"
@@ -576,7 +576,7 @@ def test_handle_started_service(
             "        Container: test-service-redis-1\n"
             "        Uptime: 1 days ago\n"
             "        Ports:\n"
-            "          http://localhost:8081 -> 8081/tcp"
+            "          127.0.0.1:8081 -> 8081/tcp"
         )
         mock_find_matching_service.assert_called_once_with("test-service")
 

--- a/tests/commands/test_status.py
+++ b/tests/commands/test_status.py
@@ -8,12 +8,518 @@ from unittest import mock
 
 import pytest
 
+from devservices.commands.status import generate_service_status_details
+from devservices.commands.status import generate_service_status_tree
+from devservices.commands.status import get_status_json_results
+from devservices.commands.status import handle_started_service
+from devservices.commands.status import parse_docker_compose_status
+from devservices.commands.status import process_service_with_local_runtime
+from devservices.commands.status import ServiceStatusOutput
 from devservices.commands.status import status
 from devservices.configs.service_config import Dependency
 from devservices.configs.service_config import ServiceConfig
+from devservices.constants import CONFIG_FILE_NAME
+from devservices.constants import DEVSERVICES_DIR_NAME
 from devservices.exceptions import DependencyError
+from devservices.exceptions import DockerComposeError
 from devservices.exceptions import ServiceNotFoundError
+from devservices.utils.dependencies import DependencyGraph
+from devservices.utils.dependencies import DependencyNode
+from devservices.utils.dependencies import DependencyType
 from devservices.utils.services import Service
+from devservices.utils.state import State
+from devservices.utils.state import StateTables
+from testing.utils import create_config_file
+from testing.utils import create_mock_git_repo
+from testing.utils import run_git_command
+
+
+def test_get_status_json_results(
+    tmp_path: Path,
+) -> None:
+    with (
+        mock.patch(
+            "devservices.commands.down.DEVSERVICES_DEPENDENCIES_CACHE_DIR",
+            str(tmp_path / "dependency-dir"),
+        ),
+        mock.patch(
+            "devservices.utils.services.get_coderoot",
+            str(tmp_path / "code"),
+        ),
+        mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")),
+    ):
+        test_service_repo_path = tmp_path / "test-service"
+        create_mock_git_repo("blank_repo", test_service_repo_path)
+        config = {
+            "x-sentry-service-config": {
+                "version": 0.1,
+                "service_name": "test-service",
+                "dependencies": {
+                    "redis": {"description": "Redis"},
+                    "clickhouse": {"description": "Clickhouse"},
+                },
+                "modes": {"default": ["redis", "clickhouse"], "test": ["redis"]},
+            },
+            "services": {
+                "redis": {"image": "redis:6.2.14-alpine"},
+                "clickhouse": {
+                    "image": "altinity/clickhouse-server:23.8.11.29.altinitystable"
+                },
+            },
+        }
+        service_path = tmp_path / "test-service"
+        create_config_file(service_path, config)
+        run_git_command(["add", "."], cwd=test_service_repo_path)
+        run_git_command(["commit", "-m", "Initial commit"], cwd=test_service_repo_path)
+        service = Service(
+            name="test-service",
+            repo_path=str(test_service_repo_path),
+            config=ServiceConfig(
+                version=0.1,
+                service_name="test-service",
+                dependencies={
+                    "redis": Dependency(description="Redis"),
+                    "clickhouse": Dependency(description="Clickhouse"),
+                },
+                modes={"default": ["redis", "clickhouse"], "test": ["redis"]},
+            ),
+        )
+
+        results = get_status_json_results(service, set(), ["redis", "clickhouse"])
+        assert len(results) == 1
+        assert results[0].args == [
+            "docker",
+            "compose",
+            "-p",
+            "test-service",
+            "-f",
+            f"{test_service_repo_path}/{DEVSERVICES_DIR_NAME}/{CONFIG_FILE_NAME}",
+            "ps",
+            "clickhouse",
+            "redis",
+            "--format",
+            "json",
+        ]
+        assert results[0].returncode == 0
+        assert results[0].stdout == ""
+        assert results[0].stderr == ""
+
+
+def test_parse_docker_compose_status() -> None:
+    mock_status = [
+        subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout='{"Service": "redis", "State": "running", "Health": "healthy", "Name": "redis", "RunningFor": "2 days ago", "Publishers": []}\n',
+        ),
+        subprocess.CompletedProcess(
+            args=[],
+            returncode=0,
+            stdout='{"Service": "kafka", "State": "running", "Health": "healthy", "Name": "kafka", "RunningFor": "2 days ago", "Publishers": []}\n',
+        ),
+    ]
+    expected_output: dict[str, ServiceStatusOutput] = {
+        "kafka": {
+            "Service": "kafka",
+            "State": "running",
+            "Health": "healthy",
+            "Name": "kafka",
+            "RunningFor": "2 days ago",
+            "Publishers": [],
+        },
+        "redis": {
+            "Service": "redis",
+            "State": "running",
+            "Health": "healthy",
+            "Name": "redis",
+            "RunningFor": "2 days ago",
+            "Publishers": [],
+        },
+    }
+    assert parse_docker_compose_status(mock_status) == expected_output
+
+
+def test_generate_service_status_details() -> None:
+    dependency = DependencyNode(
+        name="test-service",
+        dependency_type=DependencyType.SERVICE,
+    )
+    docker_compose_service_to_status: dict[str, ServiceStatusOutput] = {
+        "test-service": {
+            "Service": "test-service",
+            "State": "running",
+            "Health": "healthy",
+            "Name": "test-container",
+            "RunningFor": "2 days ago",
+            "Publishers": [
+                {
+                    "URL": "http://localhost",
+                    "PublishedPort": 8080,
+                    "TargetPort": 8080,
+                    "Protocol": "tcp",
+                }
+            ],
+        }
+    }
+    result = generate_service_status_details(
+        dependency, docker_compose_service_to_status, ""
+    )
+    assert "Type: container" in result
+    assert "Status: running" in result
+    assert "Health: \033[32mhealthy\033[0m" in result
+    assert "Container: test-container" in result
+    assert "Uptime: 2 days ago" in result
+    assert "Ports:" in result
+    assert "http://localhost:8080 -> 8080/tcp" in result
+
+
+def test_generate_service_status_tree_no_child_service(
+    tmp_path: Path,
+) -> None:
+    with mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")):
+        parent_compose = DependencyNode(
+            name="parent-container",
+            dependency_type=DependencyType.COMPOSE,
+        )
+        parent_service = DependencyNode(
+            name="parent-service",
+            dependency_type=DependencyType.SERVICE,
+        )
+        dependency_graph = DependencyGraph()
+        dependency_graph.add_edge(parent_service, parent_compose)
+        docker_compose_service_to_status: dict[str, ServiceStatusOutput] = {
+            "parent-container": {
+                "Service": "parent-container",
+                "State": "running",
+                "Health": "healthy",
+                "Name": "parent-container",
+                "RunningFor": "2 days ago",
+                "Publishers": [
+                    {
+                        "URL": "http://localhost",
+                        "PublishedPort": 8080,
+                        "TargetPort": 8080,
+                        "Protocol": "tcp",
+                    },
+                    {
+                        "URL": "http://localhost",
+                        "PublishedPort": 8081,
+                        "TargetPort": 8081,
+                        "Protocol": "tcp",
+                    },
+                ],
+            },
+        }
+        result = generate_service_status_tree(
+            "parent-service",
+            dependency_graph,
+            docker_compose_service_to_status,
+            "",
+        )
+        assert result == (
+            "\033[1mparent-service\033[0m:\n"
+            "  Type: service\n"
+            "  Runtime: local\n"
+            "  \033[1mparent-container\033[0m:\n"
+            "    Type: container\n"
+            "    Status: running\n"
+            "    Health: \033[32mhealthy\033[0m\n"
+            "    Container: parent-container\n"
+            "    Uptime: 2 days ago\n"
+            "    Ports:\n"
+            "      http://localhost:8080 -> 8080/tcp\n"
+            "      http://localhost:8081 -> 8081/tcp"
+        )
+
+
+def test_generate_service_status_tree_with_child_service(
+    tmp_path: Path,
+) -> None:
+    with mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")):
+        parent_compose = DependencyNode(
+            name="parent-container",
+            dependency_type=DependencyType.COMPOSE,
+        )
+        parent_service = DependencyNode(
+            name="parent-service",
+            dependency_type=DependencyType.SERVICE,
+        )
+        child_service = DependencyNode(
+            name="child-service",
+            dependency_type=DependencyType.SERVICE,
+        )
+        child_compose = DependencyNode(
+            name="child-container",
+            dependency_type=DependencyType.COMPOSE,
+        )
+        dependency_graph = DependencyGraph()
+        dependency_graph.add_edge(parent_service, parent_compose)
+        dependency_graph.add_edge(parent_service, child_service)
+        dependency_graph.add_edge(child_service, child_compose)
+        docker_compose_service_to_status: dict[str, ServiceStatusOutput] = {
+            "parent-container": {
+                "Service": "parent-container",
+                "State": "running",
+                "Health": "healthy",
+                "Name": "parent-container",
+                "RunningFor": "2 days ago",
+                "Publishers": [
+                    {
+                        "URL": "http://localhost",
+                        "PublishedPort": 8080,
+                        "TargetPort": 8080,
+                        "Protocol": "tcp",
+                    },
+                    {
+                        "URL": "http://localhost",
+                        "PublishedPort": 8081,
+                        "TargetPort": 8081,
+                        "Protocol": "tcp",
+                    },
+                ],
+            },
+            "child-container": {
+                "Service": "child-container",
+                "State": "running",
+                "Health": "unhealthy",
+                "Name": "child-container",
+                "RunningFor": "2 days ago",
+                "Publishers": [
+                    {
+                        "URL": "http://localhost",
+                        "PublishedPort": 8082,
+                        "TargetPort": 8082,
+                        "Protocol": "tcp",
+                    },
+                ],
+            },
+        }
+        result = generate_service_status_tree(
+            "parent-service",
+            dependency_graph,
+            docker_compose_service_to_status,
+            "",
+        )
+        assert result == (
+            "\033[1mparent-service\033[0m:\n"
+            "  Type: service\n"
+            "  Runtime: local\n"
+            "  \033[1mparent-container\033[0m:\n"
+            "    Type: container\n"
+            "    Status: running\n"
+            "    Health: \033[32mhealthy\033[0m\n"
+            "    Container: parent-container\n"
+            "    Uptime: 2 days ago\n"
+            "    Ports:\n"
+            "      http://localhost:8080 -> 8080/tcp\n"
+            "      http://localhost:8081 -> 8081/tcp\n"
+            "  \033[1mchild-service\033[0m:\n"
+            "    Type: service\n"
+            "    Runtime: containerized\n"
+            "    \033[1mchild-container\033[0m:\n"
+            "      Type: container\n"
+            "      Status: running\n"
+            "      Health: \033[91munhealthy\033[0m\n"
+            "      Container: child-container\n"
+            "      Uptime: 2 days ago\n"
+            "      Ports:\n"
+            "        http://localhost:8082 -> 8082/tcp"
+        )
+
+
+def test_generate_service_status_tree_with_nested_child_services(
+    tmp_path: Path,
+) -> None:
+    with mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")):
+        grandparent_compose = DependencyNode(
+            name="grandparent-container",
+            dependency_type=DependencyType.COMPOSE,
+        )
+        grandparent_service = DependencyNode(
+            name="grandparent-service",
+            dependency_type=DependencyType.SERVICE,
+        )
+        parent_compose = DependencyNode(
+            name="parent-container",
+            dependency_type=DependencyType.COMPOSE,
+        )
+        parent_service = DependencyNode(
+            name="parent-service",
+            dependency_type=DependencyType.SERVICE,
+        )
+        child_compose = DependencyNode(
+            name="child-container",
+            dependency_type=DependencyType.COMPOSE,
+        )
+        child_service = DependencyNode(
+            name="child-service",
+            dependency_type=DependencyType.SERVICE,
+        )
+        dependency_graph = DependencyGraph()
+        dependency_graph.add_edge(grandparent_service, grandparent_compose)
+        dependency_graph.add_edge(grandparent_service, parent_service)
+        dependency_graph.add_edge(parent_service, parent_compose)
+        dependency_graph.add_edge(parent_service, child_service)
+        dependency_graph.add_edge(child_service, child_compose)
+
+        docker_compose_service_to_status: dict[str, ServiceStatusOutput] = {
+            "grandparent-container": {
+                "Service": "grandparent-container",
+                "State": "running",
+                "Health": "healthy",
+                "Name": "grandparent-container",
+                "RunningFor": "1 days ago",
+                "Publishers": [
+                    {
+                        "URL": "http://localhost",
+                        "PublishedPort": 8080,
+                        "TargetPort": 8080,
+                        "Protocol": "tcp",
+                    },
+                ],
+            },
+            "parent-container": {
+                "Service": "parent-container",
+                "State": "running",
+                "Health": "healthy",
+                "Name": "parent-container",
+                "RunningFor": "3 days ago",
+                "Publishers": [
+                    {
+                        "URL": "http://localhost",
+                        "PublishedPort": 8081,
+                        "TargetPort": 8081,
+                        "Protocol": "tcp",
+                    },
+                ],
+            },
+            "child-container": {
+                "Service": "child-container",
+                "State": "running",
+                "Health": "starting",
+                "Name": "child-container",
+                "RunningFor": "2 days ago",
+                "Publishers": [
+                    {
+                        "URL": "http://localhost",
+                        "PublishedPort": 8082,
+                        "TargetPort": 8082,
+                        "Protocol": "tcp",
+                    },
+                ],
+            },
+        }
+        result = generate_service_status_tree(
+            "grandparent-service",
+            dependency_graph,
+            docker_compose_service_to_status,
+            "",
+        )
+        assert result == (
+            "\033[1mgrandparent-service\033[0m:\n"
+            "  Type: service\n"
+            "  Runtime: local\n"
+            "  \033[1mgrandparent-container\033[0m:\n"
+            "    Type: container\n"
+            "    Status: running\n"
+            "    Health: \033[32mhealthy\033[0m\n"
+            "    Container: grandparent-container\n"
+            "    Uptime: 1 days ago\n"
+            "    Ports:\n"
+            "      http://localhost:8080 -> 8080/tcp\n"
+            "  \033[1mparent-service\033[0m:\n"
+            "    Type: service\n"
+            "    Runtime: containerized\n"
+            "    \033[1mparent-container\033[0m:\n"
+            "      Type: container\n"
+            "      Status: running\n"
+            "      Health: \033[32mhealthy\033[0m\n"
+            "      Container: parent-container\n"
+            "      Uptime: 3 days ago\n"
+            "      Ports:\n"
+            "        http://localhost:8081 -> 8081/tcp\n"
+            "    \033[1mchild-service\033[0m:\n"
+            "      Type: service\n"
+            "      Runtime: containerized\n"
+            "      \033[1mchild-container\033[0m:\n"
+            "        Type: container\n"
+            "        Status: running\n"
+            "        Health: \033[93mstarting\033[0m\n"
+            "        Container: child-container\n"
+            "        Uptime: 2 days ago\n"
+            "        Ports:\n"
+            "          http://localhost:8082 -> 8082/tcp"
+        )
+
+
+def test_handle_started_service_invalid_config(
+    tmp_path: Path,
+) -> None:
+    with (
+        mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")),
+        mock.patch(
+            "devservices.commands.toggle.DEVSERVICES_DEPENDENCIES_CACHE_DIR",
+            str(tmp_path / "dependency-dir"),
+        ),
+        mock.patch(
+            "devservices.utils.services.get_coderoot",
+            return_value=str(tmp_path / "code"),
+        ),
+    ):
+        os.makedirs(str(tmp_path / "code" / "test-service"))
+        dependency = DependencyNode(
+            name="test-service",
+            dependency_type=DependencyType.SERVICE,
+        )
+        result = handle_started_service(dependency, "  ")
+        assert result == (
+            "  \033[1mtest-service\033[0m:\n"
+            "    Type: service\n"
+            "    Status: N/A\n"
+            "    Runtime: local"
+        )
+
+
+def test_process_service_with_local_runtime_starting(
+    tmp_path: Path,
+) -> None:
+    with (
+        mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")),
+    ):
+        state = State()
+        state.update_service_entry(
+            "test-service", "default", StateTables.STARTING_SERVICES
+        )
+        dependency = DependencyNode(
+            name="test-service",
+            dependency_type=DependencyType.SERVICE,
+        )
+        result = process_service_with_local_runtime(dependency, "  ")
+        assert result == (
+            "  \033[1mtest-service\033[0m:\n"
+            "    Type: service\n"
+            "    Status: starting\n"
+            "    Runtime: local"
+        )
+
+
+def test_process_service_with_local_runtime_not_active(
+    tmp_path: Path,
+) -> None:
+    with (
+        mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")),
+    ):
+        dependency = DependencyNode(
+            name="test-service",
+            dependency_type=DependencyType.SERVICE,
+        )
+        result = process_service_with_local_runtime(dependency, "  ")
+        assert result == (
+            "  \033[1mtest-service\033[0m:\n"
+            "    Type: service\n"
+            "    Status: N/A\n"
+            "    Runtime: local"
+        )
 
 
 def test_status_no_config_file(
@@ -36,18 +542,18 @@ def test_status_no_config_file(
     )
 
 
-@mock.patch("devservices.commands.status._status")
+@mock.patch("devservices.commands.status.get_status_for_service")
 @mock.patch("devservices.commands.status.find_matching_service")
 @mock.patch("devservices.commands.status.install_and_verify_dependencies")
 def test_status_service_not_found(
     mock_install_and_verify_dependencies: mock.Mock,
     mock_find_matching_service: mock.Mock,
-    mock_status: mock.Mock,
+    mock_get_status_for_service: mock.Mock,
     capsys: pytest.CaptureFixture[str],
 ) -> None:
-    args = Namespace(service_name="nonexistent-service")
     mock_find_matching_service.side_effect = ServiceNotFoundError("Service not found")
 
+    args = Namespace(service_name="nonexistent-service")
     with pytest.raises(SystemExit) as exc_info:
         status(args)
 
@@ -55,151 +561,111 @@ def test_status_service_not_found(
 
     mock_find_matching_service.assert_called_once_with("nonexistent-service")
     mock_install_and_verify_dependencies.assert_not_called()
-    mock_status.assert_not_called()
+    mock_get_status_for_service.assert_not_called()
 
     captured = capsys.readouterr()
     assert "Service not found" in captured.out
 
 
-@mock.patch("devservices.commands.status._status")
 @mock.patch("devservices.commands.status.find_matching_service")
 @mock.patch("devservices.commands.status.install_and_verify_dependencies")
 def test_status_dependency_error(
     mock_install_and_verify_dependencies: mock.Mock,
     mock_find_matching_service: mock.Mock,
-    mock_status: mock.Mock,
     capsys: pytest.CaptureFixture[str],
     tmp_path: Path,
 ) -> None:
-    args = Namespace(service_name="test-service")
-    service = Service(
-        name="test-service",
-        repo_path=str(tmp_path),
-        config=ServiceConfig(
-            version=0.1,
-            service_name="test-service",
-            dependencies={},
-            modes={"default": []},
-        ),
-    )
-    mock_find_matching_service.return_value = service
-    mock_install_and_verify_dependencies.side_effect = DependencyError(
-        repo_name="test-service", repo_link=str(tmp_path), branch="main"
-    )
-
-    with pytest.raises(SystemExit) as exc_info:
-        status(args)
-
-    assert exc_info.value.code == 1
-
-    mock_find_matching_service.assert_called_once_with("test-service")
-    mock_install_and_verify_dependencies.assert_called_once_with(service)
-    mock_status.assert_not_called()
-
-    captured = capsys.readouterr()
-    assert f"DependencyError: test-service ({str(tmp_path)}) on main" in captured.out
-
-
-@mock.patch("devservices.commands.status._status")
-@mock.patch("devservices.commands.status.find_matching_service")
-@mock.patch("devservices.commands.status.install_and_verify_dependencies")
-def test_status_service_not_running(
-    mock_install_and_verify_dependencies: mock.Mock,
-    mock_find_matching_service: mock.Mock,
-    mock_status: mock.Mock,
-    capsys: pytest.CaptureFixture[str],
-    tmp_path: Path,
-) -> None:
-    args = Namespace(service_name="test-service")
-    service = Service(
-        name="test-service",
-        repo_path=str(tmp_path),
-        config=ServiceConfig(
-            version=0.1,
-            service_name="test-service",
-            dependencies={},
-            modes={"default": []},
-        ),
-    )
-    mock_find_matching_service.return_value = service
-    mock_install_and_verify_dependencies.return_value = set()
-    mock_status.return_value = [
-        subprocess.CompletedProcess(args=[], returncode=0, stdout="")
-    ]
-
-    status(args)
-
-    mock_find_matching_service.assert_called_once_with("test-service")
-    mock_install_and_verify_dependencies.assert_called_once_with(service)
-    mock_status.assert_called_once_with(service, set(), [])
-
-    captured = capsys.readouterr()
-    assert "test-service is not running" in captured.out
-
-
-@mock.patch("devservices.commands.status._status")
-@mock.patch("devservices.commands.status.find_matching_service")
-@mock.patch("devservices.commands.status.install_and_verify_dependencies")
-def test_status_service_running(
-    mock_install_and_verify_dependencies: mock.Mock,
-    mock_find_matching_service: mock.Mock,
-    mock_status: mock.Mock,
-    capsys: pytest.CaptureFixture[str],
-    tmp_path: Path,
-) -> None:
-    args = Namespace(service_name="test-service")
-    service = Service(
-        name="test-service",
-        repo_path=str(tmp_path),
-        config=ServiceConfig(
-            version=0.1,
-            service_name="test-service",
-            dependencies={},
-            modes={"default": []},
-        ),
-    )
-    mock_find_matching_service.return_value = service
-    mock_install_and_verify_dependencies.return_value = set()
-    mock_status.return_value = [
-        subprocess.CompletedProcess(
-            args=[],
-            returncode=0,
-            stdout='{"Service": "test-service", "State": "running", "Name": "test-container", "Health": "healthy", "RunningFor": "2 days ago", "Publishers": [{"URL": "http://localhost:8080", "PublishedPort": 8080, "TargetPort": 8080, "Protocol": "tcp"}]}\n',
+    with (
+        mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")),
+    ):
+        state = State()
+        state.update_service_entry(
+            "test-service", "default", StateTables.STARTED_SERVICES
         )
-    ]
+        service = Service(
+            name="test-service",
+            repo_path=str(tmp_path),
+            config=ServiceConfig(
+                version=0.1,
+                service_name="test-service",
+                dependencies={},
+                modes={"default": []},
+            ),
+        )
+        mock_find_matching_service.return_value = service
+        mock_install_and_verify_dependencies.side_effect = DependencyError(
+            repo_name="test-service", repo_link=str(tmp_path), branch="main"
+        )
 
-    status(args)
+        args = Namespace(service_name="test-service")
+        with pytest.raises(SystemExit) as exc_info:
+            status(args)
 
-    mock_find_matching_service.assert_called_once_with("test-service")
-    mock_install_and_verify_dependencies.assert_called_once_with(service)
-    mock_status.assert_called_once_with(service, set(), [])
+        assert exc_info.value.code == 1
 
-    captured = capsys.readouterr()
-    assert (
-        """Service: test-service
+        mock_find_matching_service.assert_called_once_with("test-service")
+        mock_install_and_verify_dependencies.assert_called_once_with(service)
 
-========================================
-test-service
-Container: test-container
-Status: running
-Health: healthy
-Uptime: 2 days ago
-Ports:
-  http://localhost:8080:8080 -> 8080/tcp
-----------------------------------------
-
-"""
-        == captured.out
-    )
+        captured = capsys.readouterr()
+        assert (
+            f"DependencyError: test-service ({str(tmp_path)}) on main" in captured.out
+        )
 
 
-@mock.patch("devservices.commands.status._status")
 @mock.patch("devservices.commands.status.find_matching_service")
-@mock.patch("devservices.commands.status.install_and_verify_dependencies")
-def test_status_services_running_sorted_order(
+@mock.patch(
+    "devservices.commands.status.install_and_verify_dependencies", return_value=set()
+)
+@mock.patch("devservices.commands.status.get_status_json_results")
+@mock.patch("devservices.commands.status.generate_service_status_tree")
+def test_status_docker_compose_error(
+    mock_generate_service_status_tree: mock.Mock,
+    mock_get_status_json_results: mock.Mock,
     mock_install_and_verify_dependencies: mock.Mock,
     mock_find_matching_service: mock.Mock,
-    mock_status: mock.Mock,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    with (
+        mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")),
+    ):
+        state = State()
+        state.update_service_entry(
+            "test-service", "default", StateTables.STARTED_SERVICES
+        )
+        service = Service(
+            name="test-service",
+            repo_path=str(tmp_path),
+            config=ServiceConfig(
+                version=0.1,
+                service_name="test-service",
+                dependencies={},
+                modes={"default": []},
+            ),
+        )
+        mock_find_matching_service.return_value = service
+        mock_get_status_json_results.side_effect = DockerComposeError(
+            command="docker compose ps",
+            returncode=1,
+            stdout="",
+            stderr="Failed to get status for test-service: ",
+        )
+
+        args = Namespace(service_name="test-service")
+        with pytest.raises(SystemExit) as exc_info:
+            status(args)
+
+        assert exc_info.value.code == 1
+
+        captured = capsys.readouterr()
+        assert "Failed to get status for test-service: " in captured.out
+
+
+@mock.patch("devservices.commands.status.get_status_for_service")
+@mock.patch("devservices.commands.status.find_matching_service")
+def test_status_service_not_running(
+    mock_find_matching_service: mock.Mock,
+    mock_get_status_for_service: mock.Mock,
     capsys: pytest.CaptureFixture[str],
     tmp_path: Path,
 ) -> None:
@@ -210,57 +676,16 @@ def test_status_services_running_sorted_order(
         config=ServiceConfig(
             version=0.1,
             service_name="test-service",
-            dependencies={
-                "test-dependency": Dependency(
-                    description="Test dependency",
-                )
-            },
+            dependencies={},
             modes={"default": []},
         ),
     )
     mock_find_matching_service.return_value = service
-    mock_install_and_verify_dependencies.return_value = set()
-    mock_status.return_value = [
-        subprocess.CompletedProcess(
-            args=[],
-            returncode=0,
-            stdout='{"Service": "test-service", "State": "running", "Name": "test-container", "Health": "healthy", "RunningFor": "2 days ago", "Publishers": [{"URL": "http://localhost:8080", "PublishedPort": 8080, "TargetPort": 8080, "Protocol": "tcp"}]}\n',
-        ),
-        subprocess.CompletedProcess(
-            args=[],
-            returncode=0,
-            stdout='{"Service": "test-dependency", "State": "running", "Name": "test-dependency-container", "Health": "healthy", "RunningFor": "2 days ago", "Publishers": [{"URL": "http://localhost:8081", "PublishedPort": 8081, "TargetPort": 8081, "Protocol": "tcp"}]}\n',
-        ),
-    ]
 
     status(args)
 
     mock_find_matching_service.assert_called_once_with("test-service")
-    mock_install_and_verify_dependencies.assert_called_once_with(service)
-    mock_status.assert_called_once_with(service, set(), [])
+    mock_get_status_for_service.assert_not_called()
 
     captured = capsys.readouterr()
-    assert (
-        """Service: test-service
-
-========================================
-test-dependency
-Container: test-dependency-container
-Status: running
-Health: healthy
-Uptime: 2 days ago
-Ports:
-  http://localhost:8081:8081 -> 8081/tcp
-----------------------------------------
-test-service
-Container: test-container
-Status: running
-Health: healthy
-Uptime: 2 days ago
-Ports:
-  http://localhost:8080:8080 -> 8080/tcp
-----------------------------------------
-
-"""
-        == captured.out
-    )
+    assert "test-service is not running standalone" in captured.out

--- a/tests/commands/test_status.py
+++ b/tests/commands/test_status.py
@@ -164,13 +164,30 @@ def test_generate_service_status_details() -> None:
     result = generate_service_status_details(
         dependency, docker_compose_service_to_status, ""
     )
-    assert "Type: container" in result
-    assert "Status: running" in result
-    assert "Health: \033[32mhealthy\033[0m" in result
-    assert "Container: test-container" in result
-    assert "Uptime: 2 days ago" in result
-    assert "Ports:" in result
-    assert "http://localhost:8080 -> 8080/tcp" in result
+    assert result == (
+        "\033[1mtest-service\033[0m:\n"
+        "  Type: container\n"
+        "  Status: running\n"
+        "  Health: \033[32mhealthy\033[0m\n"
+        "  Container: test-container\n"
+        "  Uptime: 2 days ago\n"
+        "  Ports:\n"
+        "    http://localhost:8080 -> 8080/tcp"
+    )
+
+
+def test_generate_service_status_details_missing_status() -> None:
+    dependency = DependencyNode(
+        name="test-service",
+        dependency_type=DependencyType.SERVICE,
+    )
+    docker_compose_service_to_status: dict[str, ServiceStatusOutput] = {}
+    result = generate_service_status_details(
+        dependency, docker_compose_service_to_status, ""
+    )
+    assert result == (
+        "\033[1mtest-service\033[0m:\n" "  Type: container\n" "  Status: N/A"
+    )
 
 
 def test_generate_service_status_tree_no_child_service(

--- a/tests/commands/test_status.py
+++ b/tests/commands/test_status.py
@@ -458,7 +458,7 @@ def test_handle_started_service_invalid_config(
     with (
         mock.patch("devservices.utils.state.STATE_DB_FILE", str(tmp_path / "state")),
         mock.patch(
-            "devservices.commands.toggle.DEVSERVICES_DEPENDENCIES_CACHE_DIR",
+            "devservices.commands.status.DEVSERVICES_DEPENDENCIES_CACHE_DIR",
             str(tmp_path / "dependency-dir"),
         ),
         mock.patch(

--- a/tests/commands/test_status.py
+++ b/tests/commands/test_status.py
@@ -18,6 +18,7 @@ from devservices.commands.status import ServiceStatusOutput
 from devservices.commands.status import status
 from devservices.configs.service_config import Dependency
 from devservices.configs.service_config import ServiceConfig
+from devservices.constants import Color
 from devservices.constants import CONFIG_FILE_NAME
 from devservices.constants import DEVSERVICES_DIR_NAME
 from devservices.exceptions import DependencyError
@@ -176,10 +177,10 @@ def test_generate_service_status_details() -> None:
         dependency, docker_compose_service_to_status, ""
     )
     assert result == (
-        "\033[1mtest-service\033[0m:\n"
+        f"{Color.BOLD}test-service{Color.RESET}:\n"
         "  Type: container\n"
         "  Status: running\n"
-        "  Health: \033[32mhealthy\033[0m\n"
+        f"  Health: {Color.GREEN}healthy{Color.RESET}\n"
         "  Container: test-container\n"
         "  Uptime: 2 days ago\n"
         "  Ports:\n"
@@ -197,7 +198,9 @@ def test_generate_service_status_details_missing_status() -> None:
         dependency, docker_compose_service_to_status, ""
     )
     assert result == (
-        "\033[1mtest-service\033[0m:\n" "  Type: container\n" "  Status: N/A"
+        f"{Color.BOLD}test-service{Color.RESET}:\n"
+        "  Type: container\n"
+        "  Status: N/A"
     )
 
 
@@ -245,13 +248,13 @@ def test_generate_service_status_tree_no_child_service(
             "",
         )
         assert result == (
-            "\033[1mparent-service\033[0m:\n"
+            f"{Color.BOLD}parent-service{Color.RESET}:\n"
             "  Type: service\n"
             "  Runtime: local\n"
-            "  \033[1mparent-container\033[0m:\n"
+            f"  {Color.BOLD}parent-container{Color.RESET}:\n"
             "    Type: container\n"
             "    Status: running\n"
-            "    Health: \033[32mhealthy\033[0m\n"
+            f"    Health: {Color.GREEN}healthy{Color.RESET}\n"
             "    Container: parent-container\n"
             "    Uptime: 2 days ago\n"
             "    Ports:\n"
@@ -329,25 +332,25 @@ def test_generate_service_status_tree_with_child_service(
             "",
         )
         assert result == (
-            "\033[1mparent-service\033[0m:\n"
+            f"{Color.BOLD}parent-service{Color.RESET}:\n"
             "  Type: service\n"
             "  Runtime: local\n"
-            "  \033[1mparent-container\033[0m:\n"
+            f"  {Color.BOLD}parent-container{Color.RESET}:\n"
             "    Type: container\n"
             "    Status: running\n"
-            "    Health: \033[32mhealthy\033[0m\n"
+            f"    Health: {Color.GREEN}healthy{Color.RESET}\n"
             "    Container: parent-container\n"
             "    Uptime: 2 days ago\n"
             "    Ports:\n"
             "      http://localhost:8080 -> 8080/tcp\n"
             "      http://localhost:8081 -> 8081/tcp\n"
-            "  \033[1mchild-service\033[0m:\n"
+            f"  {Color.BOLD}child-service{Color.RESET}:\n"
             "    Type: service\n"
             "    Runtime: containerized\n"
-            "    \033[1mchild-container\033[0m:\n"
+            f"    {Color.BOLD}child-container{Color.RESET}:\n"
             "      Type: container\n"
             "      Status: running\n"
-            "      Health: \033[91munhealthy\033[0m\n"
+            f"      Health: {Color.RED}unhealthy{Color.RESET}\n"
             "      Container: child-container\n"
             "      Uptime: 2 days ago\n"
             "      Ports:\n"
@@ -444,35 +447,35 @@ def test_generate_service_status_tree_with_nested_child_services(
             "",
         )
         assert result == (
-            "\033[1mgrandparent-service\033[0m:\n"
+            f"{Color.BOLD}grandparent-service{Color.RESET}:\n"
             "  Type: service\n"
             "  Runtime: local\n"
-            "  \033[1mgrandparent-container\033[0m:\n"
+            f"  {Color.BOLD}grandparent-container{Color.RESET}:\n"
             "    Type: container\n"
             "    Status: running\n"
-            "    Health: \033[32mhealthy\033[0m\n"
+            f"    Health: {Color.GREEN}healthy{Color.RESET}\n"
             "    Container: grandparent-container\n"
             "    Uptime: 1 days ago\n"
             "    Ports:\n"
             "      http://localhost:8080 -> 8080/tcp\n"
-            "  \033[1mparent-service\033[0m:\n"
+            f"  {Color.BOLD}parent-service{Color.RESET}:\n"
             "    Type: service\n"
             "    Runtime: containerized\n"
-            "    \033[1mparent-container\033[0m:\n"
+            f"    {Color.BOLD}parent-container{Color.RESET}:\n"
             "      Type: container\n"
             "      Status: running\n"
-            "      Health: \033[32mhealthy\033[0m\n"
+            f"      Health: {Color.GREEN}healthy{Color.RESET}\n"
             "      Container: parent-container\n"
             "      Uptime: 3 days ago\n"
             "      Ports:\n"
             "        http://localhost:8081 -> 8081/tcp\n"
-            "    \033[1mchild-service\033[0m:\n"
+            f"    {Color.BOLD}child-service{Color.RESET}:\n"
             "      Type: service\n"
             "      Runtime: containerized\n"
-            "      \033[1mchild-container\033[0m:\n"
+            f"      {Color.BOLD}child-container{Color.RESET}:\n"
             "        Type: container\n"
             "        Status: running\n"
-            "        Health: \033[93mstarting\033[0m\n"
+            f"        Health: {Color.YELLOW}starting{Color.RESET}\n"
             "        Container: child-container\n"
             "        Uptime: 2 days ago\n"
             "        Ports:\n"
@@ -555,21 +558,21 @@ def test_handle_started_service(
         mock_find_matching_service.return_value = service
         result = handle_started_service(dependency, "  ")
         assert result == (
-            "    \033[1mtest-service\033[0m:\n"
+            f"    {Color.BOLD}test-service{Color.RESET}:\n"
             "      Type: service\n"
             "      Runtime: local\n"
-            "      \033[1mclickhouse\033[0m:\n"
+            f"      {Color.BOLD}clickhouse{Color.RESET}:\n"
             "        Type: container\n"
             "        Status: running\n"
-            "        Health: \033[32mhealthy\033[0m\n"
+            f"        Health: {Color.GREEN}healthy{Color.RESET}\n"
             "        Container: test-service-clickhouse-1\n"
             "        Uptime: 1 days ago\n"
             "        Ports:\n"
             "          http://localhost:8080 -> 8080/tcp\n"
-            "      \033[1mredis\033[0m:\n"
+            f"      {Color.BOLD}redis{Color.RESET}:\n"
             "        Type: container\n"
             "        Status: running\n"
-            "        Health: \033[32mhealthy\033[0m\n"
+            f"        Health: {Color.GREEN}healthy{Color.RESET}\n"
             "        Container: test-service-redis-1\n"
             "        Uptime: 1 days ago\n"
             "        Ports:\n"
@@ -644,7 +647,7 @@ def test_process_service_with_local_runtime_starting(
         )
         result = process_service_with_local_runtime(dependency, "  ")
         assert result == (
-            "  \033[1mtest-service\033[0m:\n"
+            f"  {Color.BOLD}test-service{Color.RESET}:\n"
             "    Type: service\n"
             "    Status: starting\n"
             "    Runtime: local"
@@ -663,7 +666,7 @@ def test_process_service_with_local_runtime_not_active(
         )
         result = process_service_with_local_runtime(dependency, "  ")
         assert result == (
-            "  \033[1mtest-service\033[0m:\n"
+            f"  {Color.BOLD}test-service{Color.RESET}:\n"
             "    Type: service\n"
             "    Status: N/A\n"
             "    Runtime: local"
@@ -836,4 +839,4 @@ def test_status_service_not_running(
     mock_get_status_for_service.assert_not_called()
 
     captured = capsys.readouterr()
-    assert "test-service is not running standalone" in captured.out
+    assert "Status unavailable. test-service is not running standalone" in captured.out


### PR DESCRIPTION
Revamping the status command to properly visualize the hierarchy of services and their dependencies. This includes showing which services are set to run locally (via local runtime) or are containerized (brought up by devservices automatically). With this updated logic also comes more comprehensive testing via smaller functional components.
https://linear.app/getsentry/issue/DI-647/rework-status-command
Before:
<img width="353" alt="image" src="https://github.com/user-attachments/assets/5f9eed90-4d0a-4965-93f0-2989f942fc54" />
After:
<img width="353" alt="image" src="https://github.com/user-attachments/assets/71103657-6e47-4674-bd94-ef13bb46335b" />
Note: The new version may look more repetitive because redis and kafka appear multiple times, but that is intentional since they are used by both relay and snuba.
