### PR TITLE
feat(supervisor): Generate supervisor config file to local dir

### DIFF
--- a/devservices/constants.py
+++ b/devservices/constants.py
@@ -25,6 +25,7 @@ DEVSERVICES_CACHE_DIR = os.path.expanduser("~/.cache/sentry-devservices")
 DEVSERVICES_LOCAL_DIR = os.path.expanduser("~/.local/share/sentry-devservices")
 DEVSERVICES_DEPENDENCIES_CACHE_DIR = os.path.join(DEVSERVICES_CACHE_DIR, "dependencies")
 DEVSERVICES_DEPENDENCIES_CACHE_DIR_KEY = "DEVSERVICES_DEPENDENCIES_CACHE_DIR"
+DEVSERVICES_SUPERVISOR_CONFIG_DIR = os.path.join(DEVSERVICES_LOCAL_DIR, "supervisor")
 STATE_DB_FILE = os.path.join(DEVSERVICES_LOCAL_DIR, "state")
 DEVSERVICES_ORCHESTRATOR_LABEL = "orchestrator=devservices"
 

--- a/devservices/utils/supervisor.py
+++ b/devservices/utils/supervisor.py
@@ -59,16 +59,20 @@ class SupervisorManager:
         config.read(config_file_path)
         os.makedirs(DEVSERVICES_SUPERVISOR_CONFIG_DIR, exist_ok=True)
 
+        # Set unix http server to use the socket path
         config["unix_http_server"] = {"file": self.socket_path}
 
+        # Set generated pidfile to use service name
         config["supervisord"] = {
             "pidfile": os.path.join(
                 DEVSERVICES_SUPERVISOR_CONFIG_DIR, f"{self.service_name}.pid"
             )
         }
 
+        # Set supervisorctl to use the socket path
         config["supervisorctl"] = {"serverurl": f"unix://{self.socket_path}"}
 
+        # Required by supervisor to work properly
         config["rpcinterface:supervisor"] = {
             "supervisor.rpcinterface_factory": "supervisor.rpcinterface:make_main_rpcinterface"
         }

--- a/tests/utils/test_supervisor.py
+++ b/tests/utils/test_supervisor.py
@@ -21,28 +21,28 @@ def supervisor_manager(tmp_path: Path) -> SupervisorManager:
     with mock.patch(
         "devservices.utils.supervisor.DEVSERVICES_SUPERVISOR_CONFIG_DIR", tmp_path
     ):
-        config_file = tmp_path / DEVSERVICES_DIR_NAME / "processes.conf"
-        config_file.parent.mkdir(parents=True, exist_ok=True)
-        config_file.write_text(
+        config_file_path = tmp_path / DEVSERVICES_DIR_NAME / "processes.conf"
+        config_file_path.parent.mkdir(parents=True, exist_ok=True)
+        config_file_path.write_text(
             """
     [program:test_program]
     command = python test_program.py
     """
         )
         return SupervisorManager(
-            config_file=str(config_file), service_name="test-service"
+            config_file_path=str(config_file_path), service_name="test-service"
         )
 
 
 def test_init_with_config_file(supervisor_manager: SupervisorManager) -> None:
     assert supervisor_manager.service_name == "test-service"
-    assert "test-service.processes.conf" in supervisor_manager.config_file
+    assert "test-service.processes.conf" in supervisor_manager.config_file_path
 
 
 def test_init_with_nonexistent_config() -> None:
     with pytest.raises(SupervisorConfigError):
         SupervisorManager(
-            config_file="/nonexistent/path.conf", service_name="test-service"
+            config_file_path="/nonexistent/path.conf", service_name="test-service"
         )
 
 
@@ -78,7 +78,7 @@ def test_start_supervisor_daemon_success(
 ) -> None:
     supervisor_manager.start_supervisor_daemon()
     mock_subprocess_run.assert_called_once_with(
-        ["supervisord", "-c", supervisor_manager.config_file], check=True
+        ["supervisord", "-c", supervisor_manager.config_file_path], check=True
     )
 
 
@@ -164,10 +164,10 @@ def test_stop_program_failure(
 def test_extend_config_file(
     supervisor_manager: SupervisorManager, tmp_path: Path
 ) -> None:
-    assert supervisor_manager.config_file == str(
+    assert supervisor_manager.config_file_path == str(
         tmp_path / "test-service.processes.conf"
     )
-    with open(supervisor_manager.config_file, "r") as f:
+    with open(supervisor_manager.config_file_path, "r") as f:
         assert (
             f.read()
             == f"""[program:test_program]

--- a/tests/utils/test_supervisor.py
+++ b/tests/utils/test_supervisor.py
@@ -3,8 +3,7 @@ from __future__ import annotations
 import subprocess
 import xmlrpc.client
 from pathlib import Path
-from unittest.mock import MagicMock
-from unittest.mock import patch
+from unittest import mock
 
 import pytest
 
@@ -14,59 +13,68 @@ from devservices.exceptions import SupervisorConnectionError
 from devservices.exceptions import SupervisorError
 from devservices.exceptions import SupervisorProcessError
 from devservices.utils.supervisor import SupervisorManager
+from devservices.utils.supervisor import UnixSocketTransport
 
 
 @pytest.fixture
 def supervisor_manager(tmp_path: Path) -> SupervisorManager:
-    config_file = tmp_path / DEVSERVICES_DIR_NAME / "processes.conf"
-    config_file.parent.mkdir(parents=True, exist_ok=True)
-    config_file.write_text(
-        """
-[program:test_program]
-command = python test_program.py
-"""
-    )
-    return SupervisorManager(port=6001, config_file=str(config_file))
+    with mock.patch(
+        "devservices.utils.supervisor.DEVSERVICES_SUPERVISOR_CONFIG_DIR", tmp_path
+    ):
+        config_file = tmp_path / DEVSERVICES_DIR_NAME / "processes.conf"
+        config_file.parent.mkdir(parents=True, exist_ok=True)
+        config_file.write_text(
+            """
+    [program:test_program]
+    command = python test_program.py
+    """
+        )
+        return SupervisorManager(
+            config_file=str(config_file), service_name="test-service"
+        )
 
 
 def test_init_with_config_file(supervisor_manager: SupervisorManager) -> None:
-    assert supervisor_manager.port == 6001
-    assert "devservices/processes.conf" in supervisor_manager.config_file
-
-
-def test_init_with_invalid_port() -> None:
-    with pytest.raises(SupervisorConfigError):
-        SupervisorManager(port=None)
+    assert supervisor_manager.service_name == "test-service"
+    assert "test-service.processes.conf" in supervisor_manager.config_file
 
 
 def test_init_with_nonexistent_config() -> None:
     with pytest.raises(SupervisorConfigError):
-        SupervisorManager(port=6001, config_file="/nonexistent/path.conf")
+        SupervisorManager(
+            config_file="/nonexistent/path.conf", service_name="test-service"
+        )
 
 
-@patch("devservices.utils.supervisor.xmlrpc.client.ServerProxy")
+@mock.patch("devservices.utils.supervisor.xmlrpc.client.ServerProxy")
 def test_get_rpc_client_success(
-    mock_rpc_client: MagicMock, supervisor_manager: SupervisorManager
+    mock_rpc_client: mock.MagicMock, supervisor_manager: SupervisorManager
 ) -> None:
-    mock_rpc_client.return_value = MagicMock()
+    mock_rpc_client.return_value = mock.MagicMock()
     client = supervisor_manager._get_rpc_client()
     assert client is not None
-    mock_rpc_client.assert_called_once_with("http://localhost:6001/RPC2")
+    mock_rpc_client.assert_called_once()
+    transport_arg = mock_rpc_client.call_args[1]["transport"]
+    assert isinstance(transport_arg, UnixSocketTransport)
+    assert transport_arg.socket_path == supervisor_manager.socket_path
 
 
-@patch("devservices.utils.supervisor.xmlrpc.client.ServerProxy")
+@mock.patch("devservices.utils.supervisor.xmlrpc.client.ServerProxy")
 def test_get_rpc_client_failure(
-    mock_rpc_client: MagicMock, supervisor_manager: SupervisorManager
+    mock_rpc_client: mock.MagicMock, supervisor_manager: SupervisorManager
 ) -> None:
     mock_rpc_client.side_effect = xmlrpc.client.Fault(1, "Error")
     with pytest.raises(SupervisorConnectionError):
         supervisor_manager._get_rpc_client()
-    mock_rpc_client.assert_called_once_with("http://localhost:6001/RPC2")
+    mock_rpc_client.assert_called_once()
+    transport_arg = mock_rpc_client.call_args[1]["transport"]
+    assert isinstance(transport_arg, UnixSocketTransport)
+    assert transport_arg.socket_path == supervisor_manager.socket_path
 
 
-@patch("devservices.utils.supervisor.subprocess.run")
+@mock.patch("devservices.utils.supervisor.subprocess.run")
 def test_start_supervisor_daemon_success(
-    mock_subprocess_run: MagicMock, supervisor_manager: SupervisorManager
+    mock_subprocess_run: mock.MagicMock, supervisor_manager: SupervisorManager
 ) -> None:
     supervisor_manager.start_supervisor_daemon()
     mock_subprocess_run.assert_called_once_with(
@@ -74,35 +82,35 @@ def test_start_supervisor_daemon_success(
     )
 
 
-@patch("devservices.utils.supervisor.subprocess.run")
+@mock.patch("devservices.utils.supervisor.subprocess.run")
 def test_start_supervisor_daemon_subprocess_failure(
-    mock_subprocess_run: MagicMock, supervisor_manager: SupervisorManager
+    mock_subprocess_run: mock.MagicMock, supervisor_manager: SupervisorManager
 ) -> None:
     mock_subprocess_run.side_effect = subprocess.CalledProcessError(1, "supervisord")
     with pytest.raises(SupervisorError):
         supervisor_manager.start_supervisor_daemon()
 
 
-@patch("devservices.utils.supervisor.subprocess.run")
+@mock.patch("devservices.utils.supervisor.subprocess.run")
 def test_start_supervisor_daemon_file_not_found_failure(
-    mock_subprocess_run: MagicMock, supervisor_manager: SupervisorManager
+    mock_subprocess_run: mock.MagicMock, supervisor_manager: SupervisorManager
 ) -> None:
     mock_subprocess_run.side_effect = FileNotFoundError("supervisord")
     with pytest.raises(SupervisorError):
         supervisor_manager.start_supervisor_daemon()
 
 
-@patch("devservices.utils.supervisor.xmlrpc.client.ServerProxy")
+@mock.patch("devservices.utils.supervisor.xmlrpc.client.ServerProxy")
 def test_stop_supervisor_daemon_success(
-    mock_rpc_client: MagicMock, supervisor_manager: SupervisorManager
+    mock_rpc_client: mock.MagicMock, supervisor_manager: SupervisorManager
 ) -> None:
     supervisor_manager.stop_supervisor_daemon()
     supervisor_manager._get_rpc_client().supervisor.shutdown.assert_called_once()
 
 
-@patch("devservices.utils.supervisor.xmlrpc.client.ServerProxy")
+@mock.patch("devservices.utils.supervisor.xmlrpc.client.ServerProxy")
 def test_stop_supervisor_daemon_failure(
-    mock_rpc_client: MagicMock, supervisor_manager: SupervisorManager
+    mock_rpc_client: mock.MagicMock, supervisor_manager: SupervisorManager
 ) -> None:
     mock_rpc_client.return_value.supervisor.shutdown.side_effect = xmlrpc.client.Fault(
         1, "Error"
@@ -111,9 +119,9 @@ def test_stop_supervisor_daemon_failure(
         supervisor_manager.stop_supervisor_daemon()
 
 
-@patch("devservices.utils.supervisor.xmlrpc.client.ServerProxy")
+@mock.patch("devservices.utils.supervisor.xmlrpc.client.ServerProxy")
 def test_start_program_success(
-    mock_rpc_client: MagicMock, supervisor_manager: SupervisorManager
+    mock_rpc_client: mock.MagicMock, supervisor_manager: SupervisorManager
 ) -> None:
     supervisor_manager.start_program("test_program")
     supervisor_manager._get_rpc_client().supervisor.startProcess.assert_called_once_with(
@@ -121,9 +129,9 @@ def test_start_program_success(
     )
 
 
-@patch("devservices.utils.supervisor.xmlrpc.client.ServerProxy")
+@mock.patch("devservices.utils.supervisor.xmlrpc.client.ServerProxy")
 def test_start_program_failure(
-    mock_rpc_client: MagicMock, supervisor_manager: SupervisorManager
+    mock_rpc_client: mock.MagicMock, supervisor_manager: SupervisorManager
 ) -> None:
     mock_rpc_client.return_value.supervisor.startProcess.side_effect = (
         xmlrpc.client.Fault(1, "Error")
@@ -132,9 +140,9 @@ def test_start_program_failure(
         supervisor_manager.start_program("test_program")
 
 
-@patch("devservices.utils.supervisor.xmlrpc.client.ServerProxy")
+@mock.patch("devservices.utils.supervisor.xmlrpc.client.ServerProxy")
 def test_stop_program_success(
-    mock_rpc_client: MagicMock, supervisor_manager: SupervisorManager
+    mock_rpc_client: mock.MagicMock, supervisor_manager: SupervisorManager
 ) -> None:
     supervisor_manager.stop_program("test_program")
     supervisor_manager._get_rpc_client().supervisor.stopProcess.assert_called_once_with(
@@ -142,12 +150,40 @@ def test_stop_program_success(
     )
 
 
-@patch("devservices.utils.supervisor.xmlrpc.client.ServerProxy")
+@mock.patch("devservices.utils.supervisor.xmlrpc.client.ServerProxy")
 def test_stop_program_failure(
-    mock_rpc_client: MagicMock, supervisor_manager: SupervisorManager
+    mock_rpc_client: mock.MagicMock, supervisor_manager: SupervisorManager
 ) -> None:
     mock_rpc_client.return_value.supervisor.stopProcess.side_effect = (
         xmlrpc.client.Fault(1, "Error")
     )
     with pytest.raises(SupervisorProcessError):
         supervisor_manager.stop_program("test_program")
+
+
+def test_extend_config_file(
+    supervisor_manager: SupervisorManager, tmp_path: Path
+) -> None:
+    assert supervisor_manager.config_file == str(
+        tmp_path / "test-service.processes.conf"
+    )
+    with open(supervisor_manager.config_file, "r") as f:
+        assert (
+            f.read()
+            == f"""[program:test_program]
+command = python test_program.py
+
+[unix_http_server]
+file = {tmp_path}/test-service.sock
+
+[supervisord]
+pidfile = {tmp_path}/test-service.pid
+
+[supervisorctl]
+serverurl = unix://{tmp_path}/test-service.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+"""
+        )


### PR DESCRIPTION
This is important because it abstracts config settings that are not relevant away from the end user and makes it easier to handle clashing that can happen between connections with ports.

This opens socket connections through sock files that are named after the devservices services. This prevents clashing ports entirely