### PR TITLE
fix(up): Only show skipped message once

### DIFF
--- a/devservices/commands/up.py
+++ b/devservices/commands/up.py
@@ -130,6 +130,7 @@ def up(args: Namespace) -> None:
                 in [dep.service_name for dep in remote_dependencies]
                 and service_with_local_runtime not in skipped_services
             ):
+                skipped_services.add(service_with_local_runtime)
                 status.warning(
                     f"Skipping '{service_with_local_runtime}' as it is set to run locally"
                 )

--- a/devservices/commands/up.py
+++ b/devservices/commands/up.py
@@ -91,12 +91,14 @@ def up(args: Namespace) -> None:
         services_with_local_runtime = state.get_services_by_runtime(
             ServiceRuntime.LOCAL
         )
+        skipped_services = set()
         for service_with_local_runtime in services_with_local_runtime:
             if (
                 mode in modes
                 and service_with_local_runtime != service.name
                 and service_with_local_runtime in modes[mode]
             ):
+                skipped_services.add(service_with_local_runtime)
                 status.warning(
                     f"Skipping '{service_with_local_runtime}' as it is set to run locally"
                 )
@@ -123,9 +125,11 @@ def up(args: Namespace) -> None:
         state.update_service_entry(service.name, mode, StateTables.STARTING_SERVICES)
         mode_dependencies = modes[mode]
         for service_with_local_runtime in services_with_local_runtime:
-            if service_with_local_runtime in [
-                dep.service_name for dep in remote_dependencies
-            ]:
+            if (
+                service_with_local_runtime
+                in [dep.service_name for dep in remote_dependencies]
+                and service_with_local_runtime not in skipped_services
+            ):
                 status.warning(
                     f"Skipping '{service_with_local_runtime}' as it is set to run locally"
                 )

--- a/tests/commands/test_up.py
+++ b/tests/commands/test_up.py
@@ -1317,8 +1317,10 @@ def test_up_does_not_bring_up_dependency_if_set_to_local(
 
         captured = capsys.readouterr()
         assert (
-            "Skipping 'local-runtime-service' as it is set to run locally"
-            in captured.out.strip()
+            captured.out.strip().count(
+                "Skipping 'local-runtime-service' as it is set to run locally"
+            )
+            == 1
         )
 
 
@@ -1494,8 +1496,10 @@ def test_up_does_not_bring_up_nested_dependency_if_set_to_local(
 
         captured = capsys.readouterr()
         assert (
-            "Skipping 'local-runtime-service' as it is set to run locally"
-            in captured.out.strip()
+            captured.out.strip().count(
+                "Skipping 'local-runtime-service' as it is set to run locally"
+            )
+            == 1
         )
 
 
@@ -1674,8 +1678,10 @@ def test_up_does_not_bring_up_nested_dependency_if_set_to_local_and_mode_does_no
 
         captured = capsys.readouterr()
         assert (
-            "Skipping 'local-runtime-service' as it is set to run locally"
-            not in captured.out.strip()
+            captured.out.strip().count(
+                "Skipping 'local-runtime-service' as it is set to run locally"
+            )
+            == 0
         )
 
 
@@ -1857,6 +1863,8 @@ def test_up_does_not_bring_up_dependency_if_set_to_local_and_mode_does_not_conta
 
         captured = capsys.readouterr()
         assert (
-            "Skipping 'local-runtime-service' as it is set to run locally"
-            not in captured.out.strip()
+            captured.out.strip().count(
+                "Skipping 'local-runtime-service' as it is set to run locally"
+            )
+            == 0
         )


### PR DESCRIPTION
https://linear.app/getsentry/issue/DI-684/only-show-skipped-dependencies-once-when-running-up