### PR TITLE
feat(supervisor): Add tailing logs function

### DIFF
--- a/devservices/utils/supervisor.py
+++ b/devservices/utils/supervisor.py
@@ -15,9 +15,6 @@ from devservices.exceptions import SupervisorError
 from devservices.exceptions import SupervisorProcessError
 from devservices.utils.console import Console
 
-# Supervisor process state 20 is RUNNING
-# https://supervisord.org/subprocess.html#process-states
-
 
 class SupervisorProcessState(IntEnum):
     """Supervisor process states.

--- a/devservices/utils/supervisor.py
+++ b/devservices/utils/supervisor.py
@@ -17,7 +17,8 @@ from devservices.utils.console import Console
 
 
 class SupervisorProcessState(IntEnum):
-    """Supervisor process states.
+    """
+    Supervisor process states.
 
     https://supervisord.org/subprocess.html#process-states
     """

--- a/devservices/utils/supervisor.py
+++ b/devservices/utils/supervisor.py
@@ -132,3 +132,15 @@ class SupervisorManager:
             raise SupervisorProcessError(
                 f"Failed to stop program {program_name}: {e.faultString}"
             )
+
+    def foreground_program(self, program_name: str) -> None:
+        try:
+            subprocess.run(
+                ["supervisorctl", "-c", self.config_file_path, "fg", program_name],
+                check=True,
+                stderr=subprocess.DEVNULL,
+            )
+        except subprocess.CalledProcessError as e:
+            raise SupervisorError(f"Failed to foreground {program_name}: {str(e)}")
+        except KeyboardInterrupt:
+            pass

--- a/devservices/utils/supervisor.py
+++ b/devservices/utils/supervisor.py
@@ -12,6 +12,11 @@ from devservices.exceptions import SupervisorConfigError
 from devservices.exceptions import SupervisorConnectionError
 from devservices.exceptions import SupervisorError
 from devservices.exceptions import SupervisorProcessError
+from devservices.utils.console import Console
+
+# Supervisor process state 20 is RUNNING
+# https://supervisord.org/subprocess.html#process-states
+PROGRAM_RUNNING_STATE = 20
 
 
 class UnixSocketHTTPConnection(http.client.HTTPConnection):
@@ -101,6 +106,21 @@ class SupervisorManager:
                 f"Failed to connect to supervisor XML-RPC server: {e.errmsg}"
             )
 
+    def _check_program_running(self, program_name: str) -> bool:
+        try:
+            client = self._get_rpc_client()
+            process_info = client.supervisor.getProcessInfo(program_name)
+            if not isinstance(process_info, dict):
+                return False
+
+            state = process_info.get("state")
+            if not isinstance(state, int):
+                return False
+            return state == PROGRAM_RUNNING_STATE
+        except xmlrpc.client.Fault:
+            # If we can't get the process info, assume it's not running
+            return False
+
     def start_supervisor_daemon(self) -> None:
         try:
             subprocess.run(["supervisord", "-c", self.config_file_path], check=True)
@@ -118,6 +138,8 @@ class SupervisorManager:
             raise SupervisorError(f"Failed to stop supervisor: {e.faultString}")
 
     def start_program(self, program_name: str) -> None:
+        if self._check_program_running(program_name):
+            return
         try:
             self._get_rpc_client().supervisor.startProcess(program_name)
         except xmlrpc.client.Fault as e:
@@ -126,6 +148,8 @@ class SupervisorManager:
             )
 
     def stop_program(self, program_name: str) -> None:
+        if not self._check_program_running(program_name):
+            return
         try:
             self._get_rpc_client().supervisor.stopProcess(program_name)
         except xmlrpc.client.Fault as e:
@@ -133,14 +157,26 @@ class SupervisorManager:
                 f"Failed to stop program {program_name}: {e.faultString}"
             )
 
-    def foreground_program(self, program_name: str) -> None:
+    def tail_program_logs(self, program_name: str) -> None:
+        if not self._check_program_running(program_name):
+            console = Console()
+            console.failure(f"Process {program_name} is not running")
+            return
+
         try:
+            # Use supervisorctl tail command
             subprocess.run(
-                ["supervisorctl", "-c", self.config_file_path, "fg", program_name],
+                [
+                    "supervisorctl",
+                    "-c",
+                    self.config_file_path,
+                    "tail",
+                    "-f",
+                    program_name,
+                ],
                 check=True,
-                stderr=subprocess.DEVNULL,
             )
         except subprocess.CalledProcessError as e:
-            raise SupervisorError(f"Failed to foreground {program_name}: {str(e)}")
+            raise SupervisorError(f"Failed to tail logs for {program_name}: {str(e)}")
         except KeyboardInterrupt:
             pass

--- a/tests/utils/test_supervisor.py
+++ b/tests/utils/test_supervisor.py
@@ -81,10 +81,32 @@ def test_check_program_running_success(
 
 
 @mock.patch("devservices.utils.supervisor.xmlrpc.client.ServerProxy")
-def test_check_program_running_failure(
+def test_check_program_running_program_not_running(
     mock_rpc_client: mock.MagicMock, supervisor_manager: SupervisorManager
 ) -> None:
     mock_rpc_client.return_value.supervisor.getProcessInfo.return_value = {"state": 0}
+    assert not supervisor_manager._check_program_running("test_program")
+
+
+@mock.patch("devservices.utils.supervisor.xmlrpc.client.ServerProxy")
+def test_check_program_running_typing_error(
+    mock_rpc_client: mock.MagicMock,
+    supervisor_manager: SupervisorManager,
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    mock_rpc_client.return_value.supervisor.getProcessInfo.return_value = 1
+    assert not supervisor_manager._check_program_running("test_program")
+    mock_rpc_client.return_value.supervisor.getProcessInfo.side_effect = {"state": "20"}
+    assert not supervisor_manager._check_program_running("test_program")
+
+
+@mock.patch("devservices.utils.supervisor.xmlrpc.client.ServerProxy")
+def test_check_program_running_failure(
+    mock_rpc_client: mock.MagicMock, supervisor_manager: SupervisorManager
+) -> None:
+    mock_rpc_client.return_value.supervisor.getProcessInfo.side_effect = (
+        xmlrpc.client.Fault(1, "Error")
+    )
     assert not supervisor_manager._check_program_running("test_program")
 
 
@@ -250,7 +272,7 @@ def tail_program_logs_success(
 
 @mock.patch("devservices.utils.supervisor.subprocess.run")
 @mock.patch("devservices.utils.supervisor.xmlrpc.client.ServerProxy")
-def tail_program_logs_not_running(
+def test_tail_program_logs_not_running(
     mock_rpc_client: mock.MagicMock,
     mock_subprocess_run: mock.MagicMock,
     supervisor_manager: SupervisorManager,
@@ -265,7 +287,7 @@ def tail_program_logs_not_running(
 
 @mock.patch("devservices.utils.supervisor.subprocess.run")
 @mock.patch("devservices.utils.supervisor.xmlrpc.client.ServerProxy")
-def tail_program_logs_failure(
+def test_tail_program_logs_failure(
     mock_rpc_client: mock.MagicMock,
     mock_subprocess_run: mock.MagicMock,
     supervisor_manager: SupervisorManager,
@@ -278,7 +300,7 @@ def tail_program_logs_failure(
 
 @mock.patch("devservices.utils.supervisor.subprocess.run")
 @mock.patch("devservices.utils.supervisor.xmlrpc.client.ServerProxy")
-def tail_program_logs_keyboard_interrupt(
+def test_tail_program_logs_keyboard_interrupt(
     mock_rpc_client: mock.MagicMock,
     mock_subprocess_run: mock.MagicMock,
     supervisor_manager: SupervisorManager,


### PR DESCRIPTION
Initially this was the fg command, but changed this since foregrounding a process is not reliable. 

https://linear.app/getsentry/issue/DI-663/support-retrieving-logs-of-supervisor-processes