### PR TITLE
feat: vendor docker-compose binaries

### DIFF
--- a/devservices/constants.py
+++ b/devservices/constants.py
@@ -43,7 +43,9 @@ DEVSERVICES_RELEASES_URL = (
 # We mirror this in our GCP bucket since GitHub downloads can be flaky at times.
 # gsutil cp docker-compose-darwin-aarch64 gs://sentry-dev-infra-assets/docker-compose/v2.29.7/docker-compose-darwin-aarch64
 # gsutil cp docker-compose-linux-x86_64 gs://sentry-dev-infra-assets/docker-compose/v2.29.7/docker-compose-linux-x86_64
-DOCKER_COMPOSE_DOWNLOAD_URL = "https://storage.googleapis.com/sentry-dev-infra-assets/docker-compose"
+DOCKER_COMPOSE_DOWNLOAD_URL = (
+    "https://storage.googleapis.com/sentry-dev-infra-assets/docker-compose"
+)
 
 DEVSERVICES_DOWNLOAD_URL = "https://github.com/getsentry/devservices/releases/download"
 BINARY_PERMISSIONS = 0o755

--- a/devservices/constants.py
+++ b/devservices/constants.py
@@ -39,7 +39,12 @@ DEPENDENCY_GIT_PARTIAL_CLONE_CONFIG_OPTIONS = {
 DEVSERVICES_RELEASES_URL = (
     "https://api.github.com/repos/getsentry/devservices/releases/latest"
 )
-DOCKER_COMPOSE_DOWNLOAD_URL = "https://github.com/docker/compose/releases/download"
+
+# We mirror this in our GCP bucket since GitHub downloads can be flaky at times.
+# gsutil cp docker-compose-darwin-aarch64 gs://sentry-dev-infra-assets/docker-compose/v2.29.7/docker-compose-darwin-aarch64
+# gsutil cp docker-compose-linux-x86_64 gs://sentry-dev-infra-assets/docker-compose/v2.29.7/docker-compose-linux-x86_64
+DOCKER_COMPOSE_DOWNLOAD_URL = "https://storage.googleapis.com/sentry-dev-infra-assets/docker-compose"
+
 DEVSERVICES_DOWNLOAD_URL = "https://github.com/getsentry/devservices/releases/download"
 BINARY_PERMISSIONS = 0o755
 MAX_LOG_LINES = "100"

--- a/tests/utils/test_docker_compose.py
+++ b/tests/utils/test_docker_compose.py
@@ -216,7 +216,7 @@ def test_install_docker_compose_macos_arm64(
     mock_tempdir.return_value.__enter__.return_value = "tempdir"
     install_docker_compose()
     mock_urlretrieve.assert_called_once_with(
-        "https://github.com/docker/compose/releases/download/v2.29.7/docker-compose-darwin-aarch64",
+        "https://storage.googleapis.com/sentry-dev-infra-assets/docker-compose/v2.29.7/docker-compose-darwin-aarch64",
         "tempdir/docker-compose",
     )
     mock_chmod.assert_called_once_with("tempdir/docker-compose", 0o755)
@@ -249,7 +249,7 @@ def test_install_docker_compose_linux_x86(
     mock_tempdir.return_value.__enter__.return_value = "tempdir"
     install_docker_compose()
     mock_urlretrieve.assert_called_once_with(
-        "https://github.com/docker/compose/releases/download/v2.29.7/docker-compose-linux-x86_64",
+        "https://storage.googleapis.com/sentry-dev-infra-assets/docker-compose/v2.29.7/docker-compose-linux-x86_64",
         "tempdir/docker-compose",
     )
     mock_chmod.assert_called_once_with("tempdir/docker-compose", 0o755)
@@ -286,7 +286,7 @@ def test_install_docker_compose_custom_docker_config_dir(
     ):
         install_docker_compose()
     mock_urlretrieve.assert_called_once_with(
-        "https://github.com/docker/compose/releases/download/v2.29.7/docker-compose-darwin-aarch64",
+        "https://storage.googleapis.com/sentry-dev-infra-assets/docker-compose/v2.29.7/docker-compose-darwin-aarch64",
         "tempdir/docker-compose",
     )
     mock_chmod.assert_called_once_with("tempdir/docker-compose", 0o755)


### PR DESCRIPTION
https://linear.app/getsentry/issue/DI-741/ci-failure-docker-compose-download-failure

I've copied the appropriate binaries over to our bucket.
