### PR TITLE
feat: exponentially retry pulling

### DIFF
--- a/devservices/commands/up.py
+++ b/devservices/commands/up.py
@@ -157,7 +157,9 @@ def up(args: Namespace) -> None:
 def _pull_dependency_images(
     cmd: DockerComposeCommand, current_env: dict[str, str], status: Status
 ) -> None:
-    run_cmd(cmd.full_command, current_env)
+    run_cmd(
+        cmd.full_command, current_env, retries=4, retry_initial_wait=5.0, retry_exp=2.0
+    )
     for dependency in cmd.services:
         status.info(f"Pulled image for {dependency}")
 

--- a/devservices/commands/up.py
+++ b/devservices/commands/up.py
@@ -201,6 +201,7 @@ def _up(
             )
         ),
     )
+
     # Pull all images in parallel
     status.info("Pulling images")
     pull_commands = get_docker_compose_commands_to_run(

--- a/devservices/commands/up.py
+++ b/devservices/commands/up.py
@@ -157,9 +157,7 @@ def up(args: Namespace) -> None:
 def _pull_dependency_images(
     cmd: DockerComposeCommand, current_env: dict[str, str], status: Status
 ) -> None:
-    run_cmd(
-        cmd.full_command, current_env, retries=4, retry_initial_wait=5.0, retry_exp=2.0
-    )
+    run_cmd(cmd.full_command, current_env, retries=4)
     for dependency in cmd.services:
         status.info(f"Pulled image for {dependency}")
 

--- a/devservices/utils/docker_compose.py
+++ b/devservices/utils/docker_compose.py
@@ -303,6 +303,7 @@ def run_cmd(
         raise ValueError("Retries cannot be negative")
 
     logger = logging.getLogger(LOGGER_NAME)
+    console = Console()
     cmd_pretty = shlex.join(cmd)
 
     while True:
@@ -322,7 +323,7 @@ def run_cmd(
             if retries == 0:
                 raise err
 
-            print(
+            console.warning(
                 f"""
 Error: {err}
 

--- a/devservices/utils/docker_compose.py
+++ b/devservices/utils/docker_compose.py
@@ -306,7 +306,7 @@ def run_cmd(
     console = Console()
     cmd_pretty = shlex.join(cmd)
 
-    while True:
+    while retries >= 0:
         try:
             logger.debug(f"Running command: {cmd_pretty}")
             proc = subprocess.run(

--- a/devservices/utils/docker_compose.py
+++ b/devservices/utils/docker_compose.py
@@ -306,7 +306,10 @@ def run_cmd(
     console = Console()
     cmd_pretty = shlex.join(cmd)
 
-    while retries >= 0:
+    retries += 1  # initial try
+
+    while retries > 0:
+        retries -= 1
         try:
             logger.debug(f"Running command: {cmd_pretty}")
             proc = subprocess.run(
@@ -330,7 +333,5 @@ Retrying in {retry_initial_wait}s ({retries} retries left)...
 """
             )
             time.sleep(retry_initial_wait)
-            retries -= 1
             retry_initial_wait *= retry_exp
 
-    return proc

--- a/devservices/utils/docker_compose.py
+++ b/devservices/utils/docker_compose.py
@@ -312,7 +312,6 @@ def run_cmd(
             proc = subprocess.run(
                 cmd, check=True, capture_output=True, text=True, env=env
             )
-            return proc
         except subprocess.CalledProcessError as e:
             err = DockerComposeError(
                 command=cmd_pretty,
@@ -333,3 +332,5 @@ Retrying in {retry_initial_wait}s ({retries} retries left)...
             time.sleep(retry_initial_wait)
             retries -= 1
             retry_initial_wait *= retry_exp
+
+    return proc

--- a/devservices/utils/docker_compose.py
+++ b/devservices/utils/docker_compose.py
@@ -316,6 +316,7 @@ def run_cmd(
             proc = subprocess.run(
                 cmd, check=True, capture_output=True, text=True, env=env
             )
+            return proc
         except subprocess.CalledProcessError as e:
             err = DockerComposeError(
                 command=cmd_pretty,

--- a/devservices/utils/docker_compose.py
+++ b/devservices/utils/docker_compose.py
@@ -306,6 +306,7 @@ def run_cmd(
     console = Console()
     cmd_pretty = shlex.join(cmd)
 
+    proc = None
     retries += 1  # initial try
 
     while retries > 0:
@@ -335,3 +336,6 @@ Retrying in {retry_initial_wait}s ({retries} retries left)...
             time.sleep(retry_initial_wait)
             retry_initial_wait *= retry_exp
 
+    # make mypy happy
+    assert proc is not None
+    return proc

--- a/devservices/utils/docker_compose.py
+++ b/devservices/utils/docker_compose.py
@@ -305,7 +305,7 @@ def run_cmd(
     logger = logging.getLogger(LOGGER_NAME)
     cmd_pretty = shlex.join(cmd)
 
-    while retries >= 0:
+    while True:
         try:
             logger.debug(f"Running command: {cmd_pretty}")
             proc = subprocess.run(
@@ -313,20 +313,15 @@ def run_cmd(
             )
             return proc
         except subprocess.CalledProcessError as e:
-            if retries == 0:
-                raise DockerComposeError(
-                    command=cmd_pretty,
-                    returncode=e.returncode,
-                    stdout=e.stdout,
-                    stderr=e.stderr,
-                ) from e
-
             err = DockerComposeError(
                 command=cmd_pretty,
                 returncode=e.returncode,
                 stdout=e.stdout,
                 stderr=e.stderr,
             )
+            if retries == 0:
+                raise err
+
             print(
                 f"""
 Error: {err}
@@ -337,5 +332,3 @@ Retrying in {retry_initial_wait}s ({retries} retries left)...
             time.sleep(retry_initial_wait)
             retries -= 1
             retry_initial_wait *= retry_exp
-
-    return proc

--- a/devservices/utils/docker_compose.py
+++ b/devservices/utils/docker_compose.py
@@ -5,7 +5,9 @@ import logging
 import os
 import platform
 import re
+import shlex
 import subprocess
+import time
 from typing import cast
 from typing import NamedTuple
 
@@ -290,15 +292,50 @@ def get_docker_compose_commands_to_run(
     return docker_compose_commands
 
 
-def run_cmd(cmd: list[str], env: dict[str, str]) -> subprocess.CompletedProcess[str]:
+def run_cmd(
+    cmd: list[str],
+    env: dict[str, str],
+    retries: int = 0,
+    retry_initial_wait: float = 5.0,
+    retry_exp: float = 2.0,
+) -> subprocess.CompletedProcess[str]:
+    if retries < 0:
+        raise ValueError("Retries cannot be negative")
+
     logger = logging.getLogger(LOGGER_NAME)
-    try:
-        logger.debug("Running command: %s", " ".join(cmd))
-        return subprocess.run(cmd, check=True, capture_output=True, text=True, env=env)
-    except subprocess.CalledProcessError as e:
-        raise DockerComposeError(
-            command=" ".join(cmd),
-            returncode=e.returncode,
-            stdout=e.stdout,
-            stderr=e.stderr,
-        ) from e
+    cmd_pretty = shlex.join(cmd)
+
+    while retries >= 0:
+        try:
+            logger.debug(f"Running command: {cmd_pretty}")
+            proc = subprocess.run(
+                cmd, check=True, capture_output=True, text=True, env=env
+            )
+            return proc
+        except subprocess.CalledProcessError as e:
+            if retries == 0:
+                raise DockerComposeError(
+                    command=cmd_pretty,
+                    returncode=e.returncode,
+                    stdout=e.stdout,
+                    stderr=e.stderr,
+                ) from e
+
+            err = DockerComposeError(
+                command=cmd_pretty,
+                returncode=e.returncode,
+                stdout=e.stdout,
+                stderr=e.stderr,
+            )
+            print(
+                f"""
+Error: {err}
+
+Retrying in {retry_initial_wait}s ({retries} retries left)...
+"""
+            )
+            time.sleep(retry_initial_wait)
+            retries -= 1
+            retry_initial_wait *= retry_exp
+
+    return proc

--- a/tests/commands/test_up.py
+++ b/tests/commands/test_up.py
@@ -405,7 +405,7 @@ def test_up_pull_error_timeout(
         ) as mock_subprocess_run:
             up(args)
 
-    # assert multiple failled calls
+    # assert multiple failed calls
     assert (
         mock_subprocess_run.mock_calls
         == [
@@ -427,6 +427,7 @@ def test_up_pull_error_timeout(
                 env=mock.ANY,
             )
         ]
+        # default is 4 retries (5 tries total)
         * 5
     )
 

--- a/tests/commands/test_up.py
+++ b/tests/commands/test_up.py
@@ -5,6 +5,7 @@ import subprocess
 from argparse import Namespace
 from pathlib import Path
 from unittest import mock
+from unittest.mock import call
 
 import pytest
 
@@ -337,6 +338,106 @@ def test_up_error(
     assert "Starting 'example-service' in mode: 'default'" in captured.out.strip()
     assert "Starting clickhouse" not in captured.out.strip()
     assert "Starting redis" not in captured.out.strip()
+
+
+@mock.patch("time.sleep")
+@mock.patch("devservices.utils.state.State.remove_service_entry")
+@mock.patch("devservices.utils.state.State.update_service_entry")
+@mock.patch("devservices.commands.up._create_devservices_network")
+@mock.patch("devservices.commands.up.check_all_containers_healthy")
+@mock.patch(
+    "devservices.utils.docker_compose.get_non_remote_services",
+    return_value={"clickhouse", "redis"},
+)
+def test_up_pull_error_timeout(
+    mock_get_non_remote_services: mock.Mock,
+    mock_check_all_containers_healthy: mock.Mock,
+    mock_create_devservices_network: mock.Mock,
+    mock_update_service_entry: mock.Mock,
+    mock_remove_service_entry: mock.Mock,
+    mock_sleep: mock.Mock,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    config = {
+        "x-sentry-service-config": {
+            "version": 0.1,
+            "service_name": "example-service",
+            "dependencies": {
+                "redis": {"description": "Redis"},
+                "clickhouse": {"description": "Clickhouse"},
+            },
+            "modes": {"default": ["redis", "clickhouse"]},
+        },
+        "services": {
+            "redis": {"image": "redis:6.2.14-alpine"},
+            "clickhouse": {
+                "image": "altinity/clickhouse-server:23.8.11.29.altinitystable"
+            },
+        },
+    }
+
+    create_config_file(tmp_path, config)
+    os.chdir(tmp_path)
+
+    args = Namespace(service_name=None, debug=False, mode="default")
+
+    with pytest.raises(SystemExit):
+        with mock.patch(
+            "devservices.utils.docker_compose.subprocess.run",
+            side_effect=[
+                subprocess.CalledProcessError(
+                    returncode=1, output="", stderr="TLS handshake timeout", cmd=""
+                ),
+                subprocess.CalledProcessError(
+                    returncode=1, output="", stderr="TLS handshake timeout", cmd=""
+                ),
+                subprocess.CalledProcessError(
+                    returncode=1, output="", stderr="TLS handshake timeout", cmd=""
+                ),
+                subprocess.CalledProcessError(
+                    returncode=1, output="", stderr="TLS handshake timeout", cmd=""
+                ),
+                subprocess.CalledProcessError(
+                    returncode=1, output="", stderr="TLS handshake timeout", cmd=""
+                ),
+            ],
+        ) as mock_subprocess_run:
+            up(args)
+
+    # assert multiple failled calls
+    assert (
+        mock_subprocess_run.mock_calls
+        == [
+            call(
+                [
+                    "docker",
+                    "compose",
+                    "-p",
+                    "example-service",
+                    "-f",
+                    f"{tmp_path}/{DEVSERVICES_DIR_NAME}/{CONFIG_FILE_NAME}",
+                    "pull",
+                    "clickhouse",
+                    "redis",
+                ],
+                check=True,
+                capture_output=True,
+                text=True,
+                env=mock.ANY,
+            )
+        ]
+        * 5
+    )
+
+    mock_create_devservices_network.assert_called_once()
+    mock_check_all_containers_healthy.assert_not_called()
+    # Capture the printed output
+    captured = capsys.readouterr()
+
+    assert (
+        "Failed to start example-service: TLS handshake timeout" in captured.out.strip()
+    )
 
 
 @mock.patch("devservices.utils.state.State.remove_service_entry")

--- a/tests/commands/test_up.py
+++ b/tests/commands/test_up.py
@@ -440,6 +440,119 @@ def test_up_pull_error_timeout(
     )
 
 
+@mock.patch("time.sleep")
+@mock.patch("devservices.utils.state.State.remove_service_entry")
+@mock.patch("devservices.utils.state.State.update_service_entry")
+@mock.patch("devservices.commands.up._create_devservices_network")
+@mock.patch("devservices.commands.up.check_all_containers_healthy")
+@mock.patch(
+    "devservices.utils.docker_compose.get_non_remote_services",
+    return_value={"clickhouse", "redis"},
+)
+@mock.patch(
+    "devservices.commands.up.get_container_names_for_project",
+    return_value=["x", "y"],
+)
+def test_up_pull_error_eventual_success(
+    mock_get_container_names_for_project: mock.Mock,
+    mock_get_non_remote_services: mock.Mock,
+    mock_check_all_containers_healthy: mock.Mock,
+    mock_create_devservices_network: mock.Mock,
+    mock_update_service_entry: mock.Mock,
+    mock_remove_service_entry: mock.Mock,
+    mock_sleep: mock.Mock,
+    capsys: pytest.CaptureFixture[str],
+    tmp_path: Path,
+) -> None:
+    config = {
+        "x-sentry-service-config": {
+            "version": 0.1,
+            "service_name": "example-service",
+            "dependencies": {
+                "redis": {"description": "Redis"},
+                "clickhouse": {"description": "Clickhouse"},
+            },
+            "modes": {"default": ["redis", "clickhouse"]},
+        },
+        "services": {
+            "redis": {"image": "redis:6.2.14-alpine"},
+            "clickhouse": {
+                "image": "altinity/clickhouse-server:23.8.11.29.altinitystable"
+            },
+        },
+    }
+
+    create_config_file(tmp_path, config)
+    os.chdir(tmp_path)
+
+    args = Namespace(service_name=None, debug=False, mode="default")
+
+    with mock.patch(
+        "devservices.utils.docker_compose.subprocess.run",
+        side_effect=[
+            subprocess.CalledProcessError(
+                returncode=1, output="", stderr="TLS handshake timeout", cmd=""
+            ),
+            subprocess.CalledProcessError(
+                returncode=1, output="", stderr="TLS handshake timeout", cmd=""
+            ),
+            subprocess.CompletedProcess(
+                args=(),
+                returncode=0,
+            ),
+            subprocess.CompletedProcess(
+                args=(),
+                returncode=0,
+            ),
+        ],
+    ) as mock_subprocess_run:
+        up(args)
+
+    assert mock_subprocess_run.mock_calls == [
+        call(
+            [
+                "docker",
+                "compose",
+                "-p",
+                "example-service",
+                "-f",
+                f"{tmp_path}/{DEVSERVICES_DIR_NAME}/{CONFIG_FILE_NAME}",
+                "pull",
+                "clickhouse",
+                "redis",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=mock.ANY,
+        )
+    ] * 3 + [
+        call(
+            [
+                "docker",
+                "compose",
+                "-p",
+                "example-service",
+                "-f",
+                f"{tmp_path}/{DEVSERVICES_DIR_NAME}/{CONFIG_FILE_NAME}",
+                "up",
+                "clickhouse",
+                "redis",
+                "-d",
+            ],
+            check=True,
+            capture_output=True,
+            text=True,
+            env=mock.ANY,
+        )
+    ]
+
+    mock_create_devservices_network.assert_called_once()
+    captured = capsys.readouterr()
+
+    assert "example-service started" in captured.out.strip()
+
+
 @mock.patch("devservices.utils.state.State.remove_service_entry")
 @mock.patch("devservices.utils.state.State.update_service_entry")
 @mock.patch("devservices.commands.up._create_devservices_network")


### PR DESCRIPTION
https://linear.app/getsentry/issue/DI-739/ci-failure-ghrc-image-download-tls-handshake-error

ghcr.io sometimes flakes but they're generally blips that can be retried

there's no docker compose pull retries so we have to do it ourselves

i added it to run_cmd in case we want to easily wrap other run_cmds in the future