### PR TITLE
ref(toggle): Auto bring up/down local runtimes services

### DIFF
--- a/devservices/commands/down.py
+++ b/devservices/commands/down.py
@@ -221,13 +221,11 @@ def bring_down_service(
 
     docker_compose_commands = get_docker_compose_commands_to_run(
         service=service,
-        remote_dependencies=list(
-            {
-                dep
-                for dep in remote_dependencies
-                if dep.service_name not in dependencies_with_local_runtimes
-            }
-        ),
+        remote_dependencies=[
+            dep
+            for dep in remote_dependencies
+            if dep.service_name not in dependencies_with_local_runtimes
+        ],
         current_env=current_env,
         command="stop",
         options=[],

--- a/devservices/commands/toggle.py
+++ b/devservices/commands/toggle.py
@@ -242,7 +242,7 @@ def bring_down_containerized_service(
             exit(1)
         try:
             remote_dependencies = get_non_shared_remote_dependencies(
-                service, remote_dependencies
+                service, remote_dependencies, exclude_local=True
             )
         except DependencyError as de:
             capture_exception(de)
@@ -252,7 +252,11 @@ def bring_down_containerized_service(
             exit(1)
         try:
             bring_down_service(
-                service, remote_dependencies, sorted(list(mode_dependencies)), status
+                service,
+                remote_dependencies,
+                sorted(list(mode_dependencies)),
+                True,
+                status,
             )
         except DockerComposeError as dce:
             capture_exception(dce, level="info")

--- a/devservices/commands/toggle.py
+++ b/devservices/commands/toggle.py
@@ -223,6 +223,7 @@ def bring_down_containerized_service(
 ) -> None:
     """Bring down a containerized service running within another service."""
     console = Console()
+    exclude_local = True
     with Status(
         lambda: console.warning(f"Stopping {service.name}"),
     ) as status:
@@ -242,7 +243,7 @@ def bring_down_containerized_service(
             exit(1)
         try:
             remote_dependencies = get_non_shared_remote_dependencies(
-                service, remote_dependencies, exclude_local=True
+                service, remote_dependencies, exclude_local
             )
         except DependencyError as de:
             capture_exception(de)
@@ -255,7 +256,7 @@ def bring_down_containerized_service(
                 service,
                 remote_dependencies,
                 sorted(list(mode_dependencies)),
-                True,
+                exclude_local,
                 status,
             )
         except DockerComposeError as dce:

--- a/tests/commands/test_toggle.py
+++ b/tests/commands/test_toggle.py
@@ -1218,6 +1218,7 @@ def test_bring_down_containerized_service_no_remote_dependencies(
         ),
         set(),
         ["clickhouse"],
+        True,
         mock.ANY,
     )
 
@@ -1350,6 +1351,7 @@ def test_bring_down_containerized_service_with_remote_dependency(
                     ),
                 },
                 ["clickhouse", "redis"],
+                True,
                 mock.ANY,
             ),
         ]
@@ -1443,6 +1445,7 @@ def test_bring_down_containerized_service_get_non_shared_remote_dependencies_err
             ),
         ),
         set(),
+        exclude_local=True,
     )
 
     captured = capsys.readouterr()

--- a/tests/commands/test_toggle.py
+++ b/tests/commands/test_toggle.py
@@ -1445,7 +1445,7 @@ def test_bring_down_containerized_service_get_non_shared_remote_dependencies_err
             ),
         ),
         set(),
-        exclude_local=True,
+        True,
     )
 
     captured = capsys.readouterr()

--- a/tests/utils/test_dependencies.py
+++ b/tests/utils/test_dependencies.py
@@ -2458,21 +2458,6 @@ def test_get_non_shared_remote_dependencies_with_local_runtime_dependency(
             )
         ]
     )
-    # if exclude_local:
-    #     mock_get_installed_remote_dependencies.assert_called_once_with(
-    #         [
-    #             Dependency(
-    #                 description="dependency-3",
-    #                 remote=RemoteConfig(
-    #                     repo_name="dependency-3",
-    #                     repo_link="file://path/to/dependency-3",
-    #                     branch="main",
-    #                 ),
-    #             )
-    #         ]
-    #     )
-    # else:
-    #     mock_get_installed_remote_dependencies.assert_not_called()
 
 
 @mock.patch("devservices.utils.dependencies.install_dependencies", return_value=[])


### PR DESCRIPTION
This was feedback we got from early users. In most cases, it makes sense for devservices to automatically bring up and down services local dependencies when bringing up/down dependent services. This is the default case now, and if the user wants to bring up/down a local runtime dependency in a non-default mode, they can use the --exclude-local.