### PR TITLE
chore(versioning): Bumping min python version to 3.11

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-          python-version: ["3.10", "3.11", "3.12"]
+          python-version: ["3.11", "3.12", "3.13"]
     steps:
       - name: Configure git
         run: |

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-          python-version: ["3.11", "3.12", "3.13"]
+          python-version: ["3.11", "3.12"]
     steps:
       - name: Configure git
         run: |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -5,8 +5,8 @@ build-backend = "setuptools.build_meta"
 [project]
 name = "devservices"
 version = "1.1.1"
-# 3.10 is just for internal pypi compat
-requires-python = ">=3.10"
+# 3.11 is just for internal pypi compat
+requires-python = ">=3.11"
 dependencies = [
     "pyyaml",
     "sentry-devenv",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 --index-url https://pypi.devinfra.sentry.io/simple
-pyyaml==6.0.1
+pyyaml==6.0.2
 packaging==24.0
-sentry-devenv==1.8.0
-sentry-sdk==2.20.0
+sentry-devenv==1.9.0
+sentry-sdk==2.27.0
 supervisor==4.2.5


### PR DESCRIPTION
sentry internal pypi supports python 3.11+ now, so bumping this

Also updates some other packages