### PR TITLE
fix(up/down): Fixing the exclude-local flag for up/down

### DIFF
--- a/devservices/commands/down.py
+++ b/devservices/commands/down.py
@@ -83,7 +83,7 @@ def down(args: Namespace) -> None:
         exit(1)
 
     modes = service.config.modes
-    exclude_local = args.exclude_local
+    exclude_local = getattr(args, "exclude_local", False)
 
     state = State()
     starting_services = set(state.get_service_entries(StateTables.STARTING_SERVICES))

--- a/devservices/commands/toggle.py
+++ b/devservices/commands/toggle.py
@@ -206,6 +206,7 @@ def restart_dependent_services(
                     service_name=dependent_service,
                     mode=mode,
                     debug=False,
+                    exclude_local=True,
                 )
                 try:
                     up(args)

--- a/devservices/commands/up.py
+++ b/devservices/commands/up.py
@@ -87,6 +87,7 @@ def up(args: Namespace, existing_status: Status | None = None) -> None:
 
     modes = service.config.modes
     mode = args.mode
+    exclude_local = getattr(args, "exclude_local", False)
 
     state = State()
 
@@ -109,7 +110,7 @@ def up(args: Namespace, existing_status: Status | None = None) -> None:
                 and service_with_local_runtime in modes[mode]
             ):
                 local_runtime_dependency_names.add(service_with_local_runtime)
-                if args.exclude_local:
+                if exclude_local:
                     status.warning(
                         f"Skipping '{service_with_local_runtime}' as it is set to run locally"
                     )
@@ -142,7 +143,7 @@ def up(args: Namespace, existing_status: Status | None = None) -> None:
                 and service_with_local_runtime not in local_runtime_dependency_names
             ):
                 local_runtime_dependency_names.add(service_with_local_runtime)
-                if args.exclude_local:
+                if exclude_local:
                     status.warning(
                         f"Skipping '{service_with_local_runtime}' as it is set to run locally"
                     )
@@ -155,7 +156,7 @@ def up(args: Namespace, existing_status: Status | None = None) -> None:
             for dep in remote_dependencies
             if dep.service_name not in services_with_local_runtime
         }
-        if not args.exclude_local and len(local_runtime_dependency_names) > 0:
+        if not exclude_local and len(local_runtime_dependency_names) > 0:
             status.warning("Starting dependencies with local runtimes...")
             for local_runtime_dependency_name in local_runtime_dependency_names:
                 up(

--- a/tests/commands/test_toggle.py
+++ b/tests/commands/test_toggle.py
@@ -934,6 +934,7 @@ def test_restart_dependent_services_single_dependent_service_single_mode(
             service_name="dependent-service",
             mode="default",
             debug=False,
+            exclude_local=True,
         )
     )
 
@@ -963,6 +964,7 @@ def test_restart_dependent_services_single_dependent_service_multiple_modes(
                     service_name="dependent-service",
                     mode="default",
                     debug=False,
+                    exclude_local=True,
                 )
             ),
             mock.call(
@@ -970,6 +972,7 @@ def test_restart_dependent_services_single_dependent_service_multiple_modes(
                     service_name="dependent-service",
                     mode="other-mode",
                     debug=False,
+                    exclude_local=True,
                 )
             ),
         ]
@@ -1003,6 +1006,7 @@ def test_restart_dependent_services_multiple_dependent_services_single_mode(
                     service_name="dependent-service",
                     mode="default",
                     debug=False,
+                    exclude_local=True,
                 )
             ),
             mock.call(
@@ -1010,6 +1014,7 @@ def test_restart_dependent_services_multiple_dependent_services_single_mode(
                     service_name="other-dependent-service",
                     mode="default",
                     debug=False,
+                    exclude_local=True,
                 )
             ),
         ]
@@ -1046,6 +1051,7 @@ def test_restart_dependent_services_multiple_dependent_services_multiple_modes(
                     service_name="dependent-service",
                     mode="default",
                     debug=False,
+                    exclude_local=True,
                 )
             ),
             mock.call(
@@ -1053,6 +1059,7 @@ def test_restart_dependent_services_multiple_dependent_services_multiple_modes(
                     service_name="dependent-service",
                     mode="other-mode",
                     debug=False,
+                    exclude_local=True,
                 )
             ),
             mock.call(
@@ -1060,6 +1067,7 @@ def test_restart_dependent_services_multiple_dependent_services_multiple_modes(
                     service_name="other-dependent-service",
                     mode="default",
                     debug=False,
+                    exclude_local=True,
                 )
             ),
             mock.call(
@@ -1067,6 +1075,7 @@ def test_restart_dependent_services_multiple_dependent_services_multiple_modes(
                     service_name="other-dependent-service",
                     mode="other-mode",
                     debug=False,
+                    exclude_local=True,
                 )
             ),
         ]


### PR DESCRIPTION
Ensures that not passing in `exclude_local` when calling up and down defaults to `False` as it should and doesn't cause any errors.