### PR TITLE
feat(toggle): Updating toggling active dependency to be consistent

### DIFF
--- a/devservices/commands/toggle.py
+++ b/devservices/commands/toggle.py
@@ -138,6 +138,18 @@ def handle_transition_to_local_runtime(service_to_transition: Service) -> None:
                 service_to_transition,
                 [service_to_transition_dependency_config.remote.mode],
             )
+            console.warning(f"Restarting {service_to_transition.name} in default mode")
+            # This behavior matches the default behavior of up as it
+            # will bring up dependencies with local runtimes automatically
+            # in the default mode. If the user wants to run it in a different
+            # mode, they can switch to that mode manually.
+            up(
+                Namespace(
+                    service_name=service_to_transition.name,
+                    mode="default",
+                    exclude_local=False,
+                )
+            )
             break
     state.update_service_runtime(service_to_transition.name, ServiceRuntime.LOCAL)
 

--- a/tests/commands/test_toggle.py
+++ b/tests/commands/test_toggle.py
@@ -218,9 +218,11 @@ def test_toggle_nothing_running_same_runtime(
         )
 
 
+@mock.patch("devservices.commands.toggle.up")
 @mock.patch("devservices.commands.down._bring_down_dependency")
 def test_toggle_dependent_service_running(
     mock_bring_down_dependency: mock.Mock,
+    mock_up: mock.Mock,
     tmp_path: Path,
 ) -> None:
     with (
@@ -382,6 +384,14 @@ def test_toggle_dependent_service_running(
             ),
             mock.ANY,
             mock.ANY,
+        )
+
+        mock_up.assert_called_once_with(
+            Namespace(
+                service_name="example-service",
+                mode="default",
+                exclude_local=False,
+            )
         )
 
 


### PR DESCRIPTION
Updating toggling active dependencies to be consistent with the behavior of bringing up a service with dependencies with local runtimes. When toggling a containerized dependency that is active, it should be brought down and brought back up again locally, similar to how the up command works.