### PR TITLE
feat(config): Add validation for non remote dependencies

### DIFF
--- a/devservices/commands/list_services.py
+++ b/devservices/commands/list_services.py
@@ -4,6 +4,9 @@ from argparse import _SubParsersAction
 from argparse import ArgumentParser
 from argparse import Namespace
 
+from sentry_sdk import capture_exception
+
+from devservices.exceptions import ConfigError
 from devservices.utils.console import Console
 from devservices.utils.devenv import get_coderoot
 from devservices.utils.services import get_local_services
@@ -29,7 +32,12 @@ def list_services(args: Namespace) -> None:
     console = Console()
     # Get all of the services installed locally
     coderoot = get_coderoot()
-    services = get_local_services(coderoot)
+    try:
+        services = get_local_services(coderoot)
+    except ConfigError as e:
+        capture_exception(e)
+        console.failure(str(e))
+        return
     state = State()
     starting_services = set(state.get_service_entries(StateTables.STARTING_SERVICES))
     started_services = set(state.get_service_entries(StateTables.STARTED_SERVICES))

--- a/devservices/utils/services.py
+++ b/devservices/utils/services.py
@@ -8,6 +8,7 @@ from devservices.exceptions import ConfigNotFoundError
 from devservices.exceptions import ConfigParseError
 from devservices.exceptions import ConfigValidationError
 from devservices.exceptions import ServiceNotFoundError
+from devservices.utils.console import Console
 from devservices.utils.devenv import get_coderoot
 
 
@@ -22,12 +23,15 @@ def get_local_services(coderoot: str) -> list[Service]:
     """Get a list of services in the coderoot."""
     from devservices.configs.service_config import load_service_config_from_file
 
+    console = Console()
+
     services = []
     for repo in os.listdir(coderoot):
         repo_path = os.path.join(coderoot, repo)
         try:
             service_config = load_service_config_from_file(repo_path)
         except (ConfigParseError, ConfigValidationError):
+            console.warning(f"{repo} was found with an invalid config")
             raise
         except ConfigNotFoundError:
             # Ignore repos that don't have devservices configs

--- a/devservices/utils/services.py
+++ b/devservices/utils/services.py
@@ -8,7 +8,6 @@ from devservices.exceptions import ConfigNotFoundError
 from devservices.exceptions import ConfigParseError
 from devservices.exceptions import ConfigValidationError
 from devservices.exceptions import ServiceNotFoundError
-from devservices.utils.console import Console
 from devservices.utils.devenv import get_coderoot
 
 
@@ -23,16 +22,13 @@ def get_local_services(coderoot: str) -> list[Service]:
     """Get a list of services in the coderoot."""
     from devservices.configs.service_config import load_service_config_from_file
 
-    console = Console()
-
     services = []
     for repo in os.listdir(coderoot):
         repo_path = os.path.join(coderoot, repo)
         try:
             service_config = load_service_config_from_file(repo_path)
-        except (ConfigParseError, ConfigValidationError) as e:
-            console.warning(f"{repo} was found with an invalid config: {e}")
-            continue
+        except (ConfigParseError, ConfigValidationError):
+            raise
         except ConfigNotFoundError:
             # Ignore repos that don't have devservices configs
             continue

--- a/tests/configs/test_service_config.py
+++ b/tests/configs/test_service_config.py
@@ -287,6 +287,32 @@ def test_load_service_config_from_file_remote_dependency_not_in_services(
     load_service_config_from_file(str(tmp_path))
 
 
+def test_load_service_config_from_file_no_matching_docker_compose_service(
+    tmp_path: Path,
+) -> None:
+    config = {
+        "x-sentry-service-config": {
+            "version": 0.1,
+            "service_name": "example-service",
+            "dependencies": {
+                "example-dependency": {
+                    "description": "Example dependency",
+                },
+            },
+            "modes": {"default": ["example-dependency"]},
+        },
+        "services": {},
+    }
+    create_config_file(tmp_path, config)
+
+    with pytest.raises(ConfigValidationError) as e:
+        load_service_config_from_file(str(tmp_path))
+    assert (
+        str(e.value)
+        == "Dependency 'example-dependency' is not remote but is not defined in docker-compose services"
+    )
+
+
 def test_load_service_config_from_file_invalid_dependencies(tmp_path: Path) -> None:
     config = {
         "x-sentry-service-config": {

--- a/tests/configs/test_service_config.py
+++ b/tests/configs/test_service_config.py
@@ -70,7 +70,13 @@ def test_load_service_config_from_file(
             "service_name": service_name,
             "dependencies": {key: value for key, value in dependencies.items()},
             "modes": {key: value for key, value in modes.items()},
-        }
+        },
+        "services": {
+            key: {
+                "image": key,
+            }
+            for key in dependencies.keys()
+        },
     }
     create_config_file(tmp_path, config)
 
@@ -95,7 +101,8 @@ def test_load_service_config_from_file_no_dependencies(tmp_path: Path) -> None:
             "version": 0.1,
             "service_name": "example-service",
             "modes": {"default": []},
-        }
+        },
+        "services": {},
     }
     create_config_file(tmp_path, config)
 
@@ -126,7 +133,12 @@ def test_load_service_config_from_file_invalid_version(tmp_path: Path) -> None:
                 "example-dependency": {"description": "Example dependency"}
             },
             "modes": {"default": ["example-dependency"]},
-        }
+        },
+        "services": {
+            "example-dependency": {
+                "image": "example-dependency",
+            }
+        },
     }
     create_config_file(tmp_path, config)
 
@@ -142,7 +154,12 @@ def test_load_service_config_from_file_missing_version(tmp_path: Path) -> None:
                 "example-dependency": {"description": "Example dependency"}
             },
             "modes": {"default": ["example-dependency"]},
-        }
+        },
+        "services": {
+            "example-dependency": {
+                "image": "example-dependency",
+            }
+        },
     }
     create_config_file(tmp_path, config)
 
@@ -159,7 +176,12 @@ def test_load_service_config_from_file_missing_service_name(tmp_path: Path) -> N
                 "example-dependency": {"description": "Example dependency"}
             },
             "modes": {"default": ["example-dependency"]},
-        }
+        },
+        "services": {
+            "example-dependency": {
+                "image": "example-dependency",
+            }
+        },
     }
     create_config_file(tmp_path, config)
 
@@ -177,7 +199,12 @@ def test_load_service_config_from_file_invalid_dependency(tmp_path: Path) -> Non
                 "example-dependency": {"description": "Example dependency"}
             },
             "modes": {"default": ["example-dependency", "unknown-dependency"]},
-        }
+        },
+        "services": {
+            "example-dependency": {
+                "image": "example-dependency",
+            }
+        },
     }
     create_config_file(tmp_path, config)
 
@@ -198,7 +225,12 @@ def test_load_service_config_from_file_missing_default_mode(tmp_path: Path) -> N
                 "example-dependency": {"description": "Example dependency"}
             },
             "modes": {"custom": ["example-dependency"]},
-        }
+        },
+        "services": {
+            "example-dependency": {
+                "image": "example-dependency",
+            }
+        },
     }
     create_config_file(tmp_path, config)
 
@@ -215,13 +247,44 @@ def test_load_service_config_from_file_no_modes(tmp_path: Path) -> None:
             "dependencies": {
                 "example-dependency": {"description": "Example dependency"}
             },
-        }
+        },
+        "services": {
+            "example-dependency": {
+                "image": "example-dependency",
+            }
+        },
     }
     create_config_file(tmp_path, config)
 
     with pytest.raises(ConfigValidationError) as e:
         load_service_config_from_file(str(tmp_path))
     assert str(e.value) == "Default mode is required in service config"
+
+
+def test_load_service_config_from_file_remote_dependency_not_in_services(
+    tmp_path: Path,
+) -> None:
+    config = {
+        "x-sentry-service-config": {
+            "version": 0.1,
+            "service_name": "example-service",
+            "dependencies": {
+                "example-dependency": {
+                    "description": "Example dependency",
+                    "remote": {
+                        "repo_name": "example-dependency",
+                        "repo_link": "https://github.com/example/example-dependency",
+                        "branch": "main",
+                    },
+                },
+            },
+            "modes": {"default": ["example-dependency"]},
+        },
+        "services": {},
+    }
+    create_config_file(tmp_path, config)
+
+    load_service_config_from_file(str(tmp_path))
 
 
 def test_load_service_config_from_file_invalid_dependencies(tmp_path: Path) -> None:
@@ -236,7 +299,12 @@ def test_load_service_config_from_file_invalid_dependencies(tmp_path: Path) -> N
                 }
             },
             "modes": {"default": ["example-dependency"]},
-        }
+        },
+        "services": {
+            "example-dependency": {
+                "image": "example-dependency",
+            }
+        },
     }
     create_config_file(tmp_path, config)
 
@@ -260,7 +328,12 @@ def test_load_service_config_from_file_invalid_modes(tmp_path: Path) -> None:
                 "default": ["example-dependency"],
                 "custom": "example-dependency",
             },
-        }
+        },
+        "services": {
+            "example-dependency": {
+                "image": "example-dependency",
+            }
+        },
     }
     create_config_file(tmp_path, config)
 
@@ -280,7 +353,12 @@ def test_load_service_config_from_file_no_x_sentry_service_config(
                 "example-dependency": {"description": "Example dependency"}
             },
             "modes": {"default": ["example-dependency"]},
-        }
+        },
+        "services": {
+            "example-dependency": {
+                "image": "example-dependency",
+            }
+        },
     }
     create_config_file(tmp_path, config)
 

--- a/tests/utils/test_services.py
+++ b/tests/utils/test_services.py
@@ -7,6 +7,7 @@ from unittest import mock
 import pytest
 
 from devservices.configs.service_config import ServiceConfig
+from devservices.exceptions import ConfigParseError
 from devservices.exceptions import ServiceNotFoundError
 from devservices.utils.services import find_matching_service
 from devservices.utils.services import get_local_services
@@ -32,13 +33,11 @@ def test_get_local_services_with_invalid_config(
         mock_repo_path = mock_code_root / "example"
         create_mock_git_repo("invalid_repo", mock_repo_path)
 
-        local_services = get_local_services(str(mock_code_root))
+        with pytest.raises(ConfigParseError):
+            local_services = get_local_services(str(mock_code_root))
+            assert not local_services
         captured = capsys.readouterr()
-        assert not local_services
-        assert (
-            "example was found with an invalid config: Error parsing config file:"
-            in captured.out
-        )
+        assert "example was found with an invalid config" in captured.out
 
 
 def test_get_local_services_with_valid_config(tmp_path: Path) -> None:


### PR DESCRIPTION
This adds safeguards to ensure that non-remote dependencies must have a docker compose service associated with them. It also fixes a bug where config validation fails, but the error is not raised properly

part of https://linear.app/getsentry/issue/DI-762/config-validation-for-dependencies