### PR TITLE
ref(up): Adding more context to up

### DIFF
--- a/devservices/commands/up.py
+++ b/devservices/commands/up.py
@@ -184,6 +184,7 @@ def up(args: Namespace, existing_status: Status | None = None) -> None:
         with start_span(op="service.startup", name="Start service") as span:
             span.set_data("service_name", service.name)
             span.set_data("mode", mode)
+            span.set_data("exclude_local", exclude_local)
             try:
                 _up(service, [mode], remote_dependencies, mode_dependencies, status)
             except DockerComposeError as dce:


### PR DESCRIPTION
Adding more context via spans and Sentry context. This will enable us to better track the performance of specific parts of the up command as well as better understand usage of the toggle command by tracking what dependencies are set to local runtimes when using up.

I broke off `_install_service_dependencies` as I felt it was more readable that way, especially since it would have been setting a variable in an even more nested context which would be easy to miss. I opted not to break more things off in the interest of keeping this PR on track.

I did my best to add as much context as seemed reasonable without overdoing it. If I missed anything crucial or added unnecessary context, let me know.