### PR TITLE
fix(up): Fixing local runtime dependency mode

### DIFF
--- a/devservices/commands/up.py
+++ b/devservices/commands/up.py
@@ -162,8 +162,8 @@ def up(args: Namespace, existing_status: Status | None = None) -> None:
                 up(
                     Namespace(
                         service_name=local_runtime_dependency_name,
-                        mode=mode,
-                        exclude_local=True,
+                        mode="default",  # We intentionally don't use the mode from the parent command here
+                        exclude_local=True,  # TODO: This should be False (or maybe whatever the parent command is set to)
                     ),
                     status,
                 )

--- a/tests/commands/test_up.py
+++ b/tests/commands/test_up.py
@@ -1495,7 +1495,10 @@ def test_up_dependency_set_to_local(
                         },
                     },
                 },
-                "modes": {"default": ["redis", "local-runtime-service"]},
+                "modes": {
+                    "default": ["redis", "local-runtime-service"],
+                    "other": ["redis", "local-runtime-service"],
+                },
             },
         }
         other_service_path = tmp_path / "code" / "other-service"
@@ -1507,7 +1510,7 @@ def test_up_dependency_set_to_local(
         state.update_service_runtime("local-runtime-service", ServiceRuntime.LOCAL)
 
         args = Namespace(
-            service_name=None, debug=False, mode="default", exclude_local=exclude_local
+            service_name=None, debug=False, mode="other", exclude_local=exclude_local
         )
 
         with (
@@ -1695,18 +1698,15 @@ def test_up_dependency_set_to_local(
         if exclude_local:
             mock_update_service_entry.assert_has_calls(
                 [
-                    mock.call(
-                        "other-service", "default", StateTables.STARTING_SERVICES
-                    ),
-                    mock.call("other-service", "default", StateTables.STARTED_SERVICES),
+                    mock.call("other-service", "other", StateTables.STARTING_SERVICES),
+                    mock.call("other-service", "other", StateTables.STARTED_SERVICES),
                 ]
             )
         else:
+            # Even though other-service is being brought up in mode "other", the local-runtime-service should be started in mode "default"
             mock_update_service_entry.assert_has_calls(
                 [
-                    mock.call(
-                        "other-service", "default", StateTables.STARTING_SERVICES
-                    ),
+                    mock.call("other-service", "other", StateTables.STARTING_SERVICES),
                     mock.call(
                         "local-runtime-service",
                         "default",
@@ -1715,7 +1715,7 @@ def test_up_dependency_set_to_local(
                     mock.call(
                         "local-runtime-service", "default", StateTables.STARTED_SERVICES
                     ),
-                    mock.call("other-service", "default", StateTables.STARTED_SERVICES),
+                    mock.call("other-service", "other", StateTables.STARTED_SERVICES),
                 ]
             )
 


### PR DESCRIPTION
Fixes a bug that causes dependencies with local runtimes to use the same mode as the dependent service is being brought up with instead of default. Updated our tests to make sure we properly cover this going forward. Left a TODO that I will make an issue for in linear as well.