### PR TITLE
fix(up): `devservices up` will not restart supervisor if it is already running

### DIFF
--- a/devservices/utils/supervisor.py
+++ b/devservices/utils/supervisor.py
@@ -198,7 +198,7 @@ class SupervisorManager:
             # Wait for supervisor to be ready after config reload
             self._wait_for_supervisor_ready()
             return
-        except xmlrpc.client.Fault as e:
+        except (xmlrpc.client.Fault, subprocess.CalledProcessError) as e:
             capture_exception(e, level="info")
             pass
         except (SupervisorConnectionError, socket.error, ConnectionRefusedError):

--- a/devservices/utils/supervisor.py
+++ b/devservices/utils/supervisor.py
@@ -185,7 +185,9 @@ class SupervisorManager:
             client = self._get_rpc_client()
             client.supervisor.getState()
             # Supervisor is already running, run supervisord update to update config and restart running processes
-            # Note that xmlrpc.client.reloadConfig does not work well here, so we use supervisorctl update instead
+            # Notes:
+            # - xmlrpc.client.reloadConfig does not work well here as config changes don't appear to be reloaded, so we use `supervisorctl update` instead
+            # - processes that are edited/added will not be automatically started
             subprocess.run(
                 ["supervisorctl", "-c", self.config_file_path, "update"],
                 check=True,

--- a/devservices/utils/supervisor.py
+++ b/devservices/utils/supervisor.py
@@ -184,10 +184,16 @@ class SupervisorManager:
         try:
             client = self._get_rpc_client()
             client.supervisor.getState()
-            # Supervisor is already running, restart it since config may have changed
-            client.supervisor.restart()
+            # Supervisor is already running, run supervisord update to update config and restart running processes
+            # Note that xmlrpc.client.reloadConfig does not work well here, so we use supervisorctl update instead
+            subprocess.run(
+                ["supervisorctl", "-c", self.config_file_path, "update"],
+                check=True,
+                stdout=subprocess.DEVNULL,
+                stderr=subprocess.DEVNULL,
+            )
 
-            # Wait for supervisor to be ready after restart
+            # Wait for supervisor to be ready after config reload
             self._wait_for_supervisor_ready()
             return
         except xmlrpc.client.Fault as e:

--- a/tests/utils/test_supervisor.py
+++ b/tests/utils/test_supervisor.py
@@ -195,8 +195,13 @@ def test_start_supervisor_daemon_already_running(
     }
     supervisor_manager.start_supervisor_daemon()
     assert mock_rpc_client.return_value.supervisor.getState.call_count == 2
-    assert mock_rpc_client.return_value.supervisor.restart.call_count == 1
-    assert mock_subprocess_run.call_count == 0
+    mock_subprocess_run.assert_called_with(
+        ["supervisorctl", "-c", supervisor_manager.config_file_path, "update"],
+        check=True,
+        stdout=subprocess.DEVNULL,
+        stderr=subprocess.DEVNULL,
+    )
+    assert mock_subprocess_run.call_count == 1
 
 
 @mock.patch("devservices.utils.supervisor.subprocess.run")

--- a/tests/utils/test_supervisor.py
+++ b/tests/utils/test_supervisor.py
@@ -201,7 +201,7 @@ def test_start_supervisor_daemon_already_running(
         stdout=subprocess.DEVNULL,
         stderr=subprocess.DEVNULL,
     )
-    assert mock_subprocess_run.call_count == 1
+    mock_subprocess_run.assert_called_once()
 
 
 @mock.patch("devservices.utils.supervisor.subprocess.run")


### PR DESCRIPTION
This change makes it so that config changes are picked up on `devservices up` invocations. Edited or new programs will not be automatically be brought up. This means that if a config change goes in for a program that is currently running, the mode with the program must be brought up again. This behavior seems fine for now, and we can add on functionality later on to ensure the same programs running before are brought up again but seems lower priority