### PR TITLE
chore(config): Consolidate programs.conf file into config.yml

### DIFF
--- a/devservices/commands/down.py
+++ b/devservices/commands/down.py
@@ -15,12 +15,12 @@ from devservices.constants import DependencyType
 from devservices.constants import DEVSERVICES_DEPENDENCIES_CACHE_DIR
 from devservices.constants import DEVSERVICES_DEPENDENCIES_CACHE_DIR_KEY
 from devservices.constants import DEVSERVICES_DIR_NAME
-from devservices.constants import PROGRAMS_CONF_FILE_NAME
 from devservices.exceptions import ConfigError
 from devservices.exceptions import ConfigNotFoundError
 from devservices.exceptions import DependencyError
 from devservices.exceptions import DockerComposeError
 from devservices.exceptions import ServiceNotFoundError
+from devservices.exceptions import SupervisorConfigError
 from devservices.exceptions import SupervisorError
 from devservices.utils.console import Console
 from devservices.utils.console import Status
@@ -310,13 +310,15 @@ def bring_down_supervisor_programs(
 ) -> None:
     if len(supervisor_programs) == 0:
         return
-    programs_config_path = os.path.join(
-        service.repo_path, f"{DEVSERVICES_DIR_NAME}/{PROGRAMS_CONF_FILE_NAME}"
+
+    config_file_path = os.path.join(
+        service.repo_path, DEVSERVICES_DIR_NAME, CONFIG_FILE_NAME
     )
-    manager = SupervisorManager(
-        programs_config_path,
-        service_name=service.name,
-    )
+
+    try:
+        manager = SupervisorManager(service.name, config_file_path)
+    except SupervisorConfigError:
+        raise
 
     for program in supervisor_programs:
         status.info(f"Stopping {program}")

--- a/devservices/commands/foreground.py
+++ b/devservices/commands/foreground.py
@@ -9,9 +9,9 @@ from argparse import Namespace
 
 from sentry_sdk import capture_exception
 
+from devservices.constants import CONFIG_FILE_NAME
 from devservices.constants import DependencyType
 from devservices.constants import DEVSERVICES_DIR_NAME
-from devservices.constants import PROGRAMS_CONF_FILE_NAME
 from devservices.exceptions import ConfigError
 from devservices.exceptions import ConfigNotFoundError
 from devservices.exceptions import ServiceNotFoundError
@@ -92,14 +92,15 @@ def foreground(args: Namespace) -> None:
         )
         return
 
-    programs_config_path = os.path.join(
-        service.repo_path, f"{DEVSERVICES_DIR_NAME}/{PROGRAMS_CONF_FILE_NAME}"
+    config_file_path = os.path.join(
+        service.repo_path, DEVSERVICES_DIR_NAME, CONFIG_FILE_NAME
     )
 
-    manager = SupervisorManager(
-        programs_config_path,
-        service_name=service.name,
-    )
+    try:
+        manager = SupervisorManager(service.name, config_file_path)
+    except SupervisorConfigError as e:
+        capture_exception(e, level="info")
+        return
 
     try:
         program_command = manager.get_program_command(program_name)

--- a/devservices/commands/logs.py
+++ b/devservices/commands/logs.py
@@ -16,7 +16,6 @@ from devservices.constants import DEVSERVICES_DEPENDENCIES_CACHE_DIR
 from devservices.constants import DEVSERVICES_DEPENDENCIES_CACHE_DIR_KEY
 from devservices.constants import DEVSERVICES_DIR_NAME
 from devservices.constants import MAX_LOG_LINES
-from devservices.constants import PROGRAMS_CONF_FILE_NAME
 from devservices.exceptions import ConfigError
 from devservices.exceptions import ConfigNotFoundError
 from devservices.exceptions import DependencyError
@@ -178,12 +177,11 @@ def _supervisor_logs(
 
     supervisor_logs: dict[str, str] = {}
 
-    programs_config_path = os.path.join(
-        service.repo_path, DEVSERVICES_DIR_NAME, PROGRAMS_CONF_FILE_NAME
+    config_file_path = os.path.join(
+        service.repo_path, DEVSERVICES_DIR_NAME, CONFIG_FILE_NAME
     )
-
     try:
-        manager = SupervisorManager(programs_config_path, service_name=service.name)
+        manager = SupervisorManager(service.name, config_file_path)
     except SupervisorConfigError as e:
         capture_exception(e)
         return supervisor_logs

--- a/devservices/commands/serve.py
+++ b/devservices/commands/serve.py
@@ -9,8 +9,8 @@ from argparse import Namespace
 
 from sentry_sdk import capture_exception
 
+from devservices.constants import CONFIG_FILE_NAME
 from devservices.constants import DEVSERVICES_DIR_NAME
-from devservices.constants import PROGRAMS_CONF_FILE_NAME
 from devservices.exceptions import ConfigError
 from devservices.exceptions import ConfigNotFoundError
 from devservices.exceptions import SupervisorConfigError
@@ -46,16 +46,16 @@ def serve(args: Namespace) -> None:
         console.failure(str(e))
         exit(1)
 
-    programs_config_path = os.path.join(
-        service.repo_path, f"{DEVSERVICES_DIR_NAME}/{PROGRAMS_CONF_FILE_NAME}"
+    config_file_path = os.path.join(
+        service.repo_path, DEVSERVICES_DIR_NAME, CONFIG_FILE_NAME
     )
-    if not os.path.exists(programs_config_path):
-        console.failure(f"No programs.conf file found in {programs_config_path}.")
+
+    try:
+        manager = SupervisorManager(service.name, config_file_path)
+    except SupervisorConfigError as e:
+        capture_exception(e, level="info")
+        console.failure("Unable to bring up devserver due to supervisor config error.")
         return
-    manager = SupervisorManager(
-        programs_config_path,
-        service_name=service.name,
-    )
 
     try:
         devserver_command = manager.get_program_command("devserver")

--- a/devservices/commands/serve.py
+++ b/devservices/commands/serve.py
@@ -54,7 +54,9 @@ def serve(args: Namespace) -> None:
         manager = SupervisorManager(service.name, config_file_path)
     except SupervisorConfigError as e:
         capture_exception(e, level="info")
-        console.failure("Unable to bring up devserver due to supervisor config error.")
+        console.failure(
+            f"Unable to bring up devserver due to supervisor config error: {str(e)}"
+        )
         return
 
     try:

--- a/devservices/commands/serve.py
+++ b/devservices/commands/serve.py
@@ -59,6 +59,12 @@ def serve(args: Namespace) -> None:
         )
         return
 
+    if not manager.has_programs:
+        console.failure(
+            "No programs found in config. Please add the devserver in the `x-programs` block to your config.yml"
+        )
+        return
+
     try:
         devserver_command = manager.get_program_command("devserver")
     except SupervisorConfigError as e:

--- a/devservices/commands/up.py
+++ b/devservices/commands/up.py
@@ -17,7 +17,6 @@ from devservices.constants import DependencyType
 from devservices.constants import DEVSERVICES_DEPENDENCIES_CACHE_DIR
 from devservices.constants import DEVSERVICES_DEPENDENCIES_CACHE_DIR_KEY
 from devservices.constants import DEVSERVICES_DIR_NAME
-from devservices.constants import PROGRAMS_CONF_FILE_NAME
 from devservices.exceptions import ConfigError
 from devservices.exceptions import ConfigNotFoundError
 from devservices.exceptions import ContainerHealthcheckFailedError
@@ -25,6 +24,7 @@ from devservices.exceptions import DependencyError
 from devservices.exceptions import DockerComposeError
 from devservices.exceptions import ModeDoesNotExistError
 from devservices.exceptions import ServiceNotFoundError
+from devservices.exceptions import SupervisorConfigError
 from devservices.exceptions import SupervisorError
 from devservices.utils.console import Console
 from devservices.utils.console import Status
@@ -391,14 +391,15 @@ def bring_up_supervisor_programs(
             f"Cannot bring up supervisor programs from outside the service repository. Please run the command from the service repository ({service.repo_path})"
         )
         return
-    programs_config_path = os.path.join(
-        service.repo_path, f"{DEVSERVICES_DIR_NAME}/{PROGRAMS_CONF_FILE_NAME}"
+
+    config_file_path = os.path.join(
+        service.repo_path, DEVSERVICES_DIR_NAME, CONFIG_FILE_NAME
     )
 
-    manager = SupervisorManager(
-        programs_config_path,
-        service_name=service.name,
-    )
+    try:
+        manager = SupervisorManager(service.name, config_file_path)
+    except SupervisorConfigError:
+        raise
 
     status.info("Starting supervisor daemon")
     manager.start_supervisor_daemon()

--- a/devservices/constants.py
+++ b/devservices/constants.py
@@ -25,7 +25,6 @@ class DependencyType(StrEnum):
 MINIMUM_DOCKER_COMPOSE_VERSION = "2.29.7"
 DEVSERVICES_DIR_NAME = "devservices"
 CONFIG_FILE_NAME = "config.yml"
-PROGRAMS_CONF_FILE_NAME = "programs.conf"
 DOCKER_CONFIG_DIR = os.environ.get("DOCKER_CONFIG", os.path.expanduser("~/.docker"))
 DOCKER_USER_PLUGIN_DIR = os.path.join(DOCKER_CONFIG_DIR, "cli-plugins/")
 

--- a/devservices/utils/supervisor.py
+++ b/devservices/utils/supervisor.py
@@ -8,7 +8,9 @@ import subprocess
 import time
 import xmlrpc.client
 from enum import IntEnum
+from typing import TypedDict
 
+import yaml
 from sentry_sdk import capture_exception
 from supervisor.options import ServerOptions
 
@@ -76,24 +78,83 @@ class UnixSocketTransport(xmlrpc.client.Transport):
         return UnixSocketHTTPConnection(self.socket_path)
 
 
+class SupervisorProgramConfig(TypedDict, total=False):
+    """Supervisor program configuration."""
+
+    command: str
+    autostart: str | bool
+    autorestart: str | bool
+    directory: str
+    environment: str
+    user: str
+    priority: str | int
+    startsecs: str | int
+    startretries: str | int
+    stdout_logfile: str
+    stderr_logfile: str
+    redirect_stderr: str | bool
+
+
+ProgramData = dict[str, SupervisorProgramConfig]
+
+
+# Default values for supervisor program configuration
+SUPERVISOR_PROGRAM_DEFAULTS = {
+    "autostart": "false",
+    "autorestart": "true",
+}
+
+
 class SupervisorManager:
-    def __init__(self, config_file_path: str, service_name: str) -> None:
+    def __init__(
+        self,
+        service_name: str,
+        service_config_path: str,
+    ) -> None:
         self.service_name = service_name
-        if not os.path.exists(config_file_path):
-            raise SupervisorConfigError(
-                f"Config file {config_file_path} does not exist"
-            )
         self.socket_path = os.path.join(
             DEVSERVICES_SUPERVISOR_CONFIG_DIR, f"{service_name}.sock"
         )
-        self.config_file_path = self._extend_config_file(config_file_path)
 
-    def _extend_config_file(self, config_file_path: str) -> str:
-        """Extend the supervisor config file passed into devservices with configuration settings that should be abstracted from users."""
+        # Load service config and extract x-programs data
+        if os.path.exists(service_config_path):
+            with open(service_config_path, "r", encoding="utf-8") as stream:
+                config = yaml.safe_load(stream)
+        else:
+            raise SupervisorConfigError(f"Config file {service_config_path} not found")
 
+        if config is None:
+            raise SupervisorConfigError(f"Config file {service_config_path} is empty")
+
+        programs_data: ProgramData = config.get("x-programs", {})
+        print(programs_data)
+
+        if not programs_data:
+            raise SupervisorConfigError("No x-programs block found in config.yml")
+
+        # Generate supervisor config file from x-programs data
+        self.config_file_path = self._generate_config_from_programs_data(programs_data)
+
+    def _generate_config_from_programs_data(self, programs_data: ProgramData) -> str:
         config = configparser.ConfigParser()
 
-        config.read(config_file_path)
+        # Add program sections
+        for program_name, program_config in programs_data.items():
+            section_name = f"program:{program_name}"
+            config[section_name] = {}
+
+            # Apply defaults for any missing configuration values
+            program_config_with_defaults = {
+                **SUPERVISOR_PROGRAM_DEFAULTS,
+                **program_config,
+            }
+
+            for key, value in program_config_with_defaults.items():
+                if isinstance(value, bool):
+                    config[section_name][key] = str(value).lower()
+                else:
+                    config[section_name][key] = str(value)
+
         os.makedirs(DEVSERVICES_SUPERVISOR_CONFIG_DIR, exist_ok=True)
 
         # Set unix http server to use the socket path
@@ -114,13 +175,13 @@ class SupervisorManager:
             "supervisor.rpcinterface_factory": "supervisor.rpcinterface:make_main_rpcinterface"
         }
 
-        extended_config_file_path = os.path.join(
+        config_file_path = os.path.join(
             DEVSERVICES_SUPERVISOR_CONFIG_DIR, f"{self.service_name}.processes.conf"
         )
-        with open(extended_config_file_path, "w") as f:
+        with open(config_file_path, "w") as f:
             config.write(f)
 
-        return extended_config_file_path
+        return config_file_path
 
     def _get_rpc_client(self) -> xmlrpc.client.ServerProxy:
         """Get or create an XML-RPC client that connects to the supervisor daemon."""

--- a/devservices/utils/supervisor.py
+++ b/devservices/utils/supervisor.py
@@ -142,8 +142,7 @@ class SupervisorManager:
 
         programs_data: ProgramData = config.get("x-programs", {})
 
-        if not programs_data:
-            raise SupervisorConfigError("No x-programs block found in config.yml")
+        self.has_programs = len(programs_data.keys()) > 0
 
         # Generate supervisor config file from x-programs data
         self.config_file_path = self._generate_config_from_programs_data(programs_data)
@@ -376,6 +375,9 @@ class SupervisorManager:
     def get_all_process_info(self) -> dict[str, ProcessInfo]:
         """Get status information for all supervisor programs."""
         # Check if supervisor client is up first, return empty list if down
+        if not self.has_programs:
+            return {}
+
         try:
             client = self._get_rpc_client()
             client.supervisor.getState()

--- a/devservices/utils/supervisor.py
+++ b/devservices/utils/supervisor.py
@@ -127,7 +127,6 @@ class SupervisorManager:
             raise SupervisorConfigError(f"Config file {service_config_path} is empty")
 
         programs_data: ProgramData = config.get("x-programs", {})
-        print(programs_data)
 
         if not programs_data:
             raise SupervisorConfigError("No x-programs block found in config.yml")

--- a/testing/utils.py
+++ b/testing/utils.py
@@ -8,7 +8,6 @@ from pathlib import Path
 import yaml
 
 from devservices.constants import DEVSERVICES_DIR_NAME
-from devservices.constants import PROGRAMS_CONF_FILE_NAME
 
 TESTING_DIR = os.path.abspath(os.path.dirname(__file__))
 
@@ -25,14 +24,6 @@ def create_config_file(
     tmp_file = Path(devservices_dir, "config.yml")
     with tmp_file.open("w") as f:
         yaml.dump(config, f, sort_keys=False, default_flow_style=False)
-
-
-def create_programs_conf_file(tmp_path: Path, config: str) -> None:
-    devservices_dir = Path(tmp_path, DEVSERVICES_DIR_NAME)
-    devservices_dir.mkdir(parents=True, exist_ok=True)
-    tmp_file = Path(devservices_dir, PROGRAMS_CONF_FILE_NAME)
-    with tmp_file.open("w") as f:
-        f.write(config)
 
 
 def run_git_command(command: list[str], cwd: Path) -> None:

--- a/tests/commands/test_down.py
+++ b/tests/commands/test_down.py
@@ -18,7 +18,6 @@ from devservices.constants import DependencyType
 from devservices.constants import DEVSERVICES_DIR_NAME
 from devservices.exceptions import ConfigError
 from devservices.exceptions import ServiceNotFoundError
-from devservices.exceptions import SupervisorConfigError
 from devservices.exceptions import SupervisorError
 from devservices.utils.dependencies import install_and_verify_dependencies
 from devservices.utils.docker_compose import DockerComposeCommand
@@ -1472,50 +1471,6 @@ def test_down_supervisor_program_success(
         assert "Stopping supervisor-program" in captured.out.strip()
         assert "Stopping supervisor daemon" in captured.out.strip()
         assert "example-service stopped" in captured.out.strip()
-
-
-@mock.patch("devservices.utils.supervisor.SupervisorManager.stop_supervisor_daemon")
-@mock.patch("devservices.utils.supervisor.SupervisorManager.stop_process")
-def test_bring_down_supervisor_programs_no_programs_config(
-    mock_stop_process: mock.Mock,
-    mock_stop_supervisor_daemon: mock.Mock,
-    tmp_path: Path,
-) -> None:
-    service_config = ServiceConfig(
-        version=0.1,
-        service_name="test-service",
-        dependencies={
-            "supervisor-program": Dependency(
-                description="Supervisor program",
-                dependency_type=DependencyType.SUPERVISOR,
-            ),
-        },
-        modes={"default": ["supervisor-program"]},
-    )
-    service = Service(
-        name="test-service",
-        repo_path=str(tmp_path),
-        config=service_config,
-    )
-
-    status = mock.MagicMock()
-
-    # Create a config file without x-programs block
-    config = {
-        "x-sentry-service-config": {
-            "version": 0.1,
-            "service_name": "test-service",
-            "services": {},
-        },
-    }
-    create_config_file(tmp_path, config)
-    with pytest.raises(
-        SupervisorConfigError, match="No x-programs block found in config.yml"
-    ):
-        bring_down_supervisor_programs(["supervisor-program"], service, status)
-
-    mock_stop_supervisor_daemon.assert_not_called()
-    mock_stop_process.assert_not_called()
 
 
 @mock.patch("devservices.utils.supervisor.SupervisorManager.stop_supervisor_daemon")

--- a/tests/commands/test_foreground.py
+++ b/tests/commands/test_foreground.py
@@ -18,7 +18,6 @@ from devservices.exceptions import SupervisorProcessError
 from devservices.utils.state import State
 from devservices.utils.state import StateTables
 from testing.utils import create_config_file
-from testing.utils import create_programs_conf_file
 
 
 @mock.patch("devservices.commands.foreground.pty.spawn")
@@ -40,6 +39,11 @@ def test_foreground_success(
             },
             "modes": {"default": ["redis", "worker"]},
         },
+        "x-programs": {
+            "worker": {
+                "command": "python worker.py",
+            },
+        },
         "services": {
             "redis": {"image": "redis:6.2.14-alpine"},
         },
@@ -48,14 +52,6 @@ def test_foreground_success(
     service_path = tmp_path / "example-service"
     create_config_file(service_path, config)
     os.chdir(service_path)
-
-    programs_config = """
-[program:worker]
-command=python worker.py
-autostart=true
-autorestart=true
-"""
-    create_programs_conf_file(service_path, programs_config)
 
     args = Namespace(program_name="worker")
 
@@ -86,19 +82,16 @@ def test_foreground_service_not_running(
             },
             "modes": {"default": ["worker"]},
         },
+        "x-programs": {
+            "worker": {
+                "command": "python worker.py",
+            },
+        },
     }
 
     service_path = tmp_path / "example-service"
     create_config_file(service_path, config)
     os.chdir(service_path)
-
-    programs_config = """
-[program:worker]
-command=python worker.py
-autostart=true
-autorestart=true
-"""
-    create_programs_conf_file(service_path, programs_config)
 
     args = Namespace(program_name="worker")
 
@@ -129,6 +122,11 @@ def test_foreground_program_not_in_supervisor_programs(
             },
             "modes": {"default": ["redis", "worker"]},
         },
+        "x-programs": {
+            "worker": {
+                "command": "python worker.py",
+            },
+        },
         "services": {
             "redis": {"image": "redis:6.2.14-alpine"},
         },
@@ -137,14 +135,6 @@ def test_foreground_program_not_in_supervisor_programs(
     service_path = tmp_path / "example-service"
     create_config_file(service_path, config)
     os.chdir(service_path)
-
-    programs_config = """
-[program:worker]
-command=python worker.py
-autostart=true
-autorestart=true
-"""
-    create_programs_conf_file(service_path, programs_config)
 
     args = Namespace(program_name="nonexistent")
 
@@ -180,6 +170,11 @@ def test_foreground_program_not_in_active_modes(
             },
             "modes": {"default": ["redis"], "other": ["worker"]},
         },
+        "x-programs": {
+            "worker": {
+                "command": "python worker.py",
+            },
+        },
         "services": {
             "redis": {"image": "redis:6.2.14-alpine"},
         },
@@ -188,14 +183,6 @@ def test_foreground_program_not_in_active_modes(
     service_path = tmp_path / "example-service"
     create_config_file(service_path, config)
     os.chdir(service_path)
-
-    programs_config = """
-[program:worker]
-command=python worker.py
-autostart=true
-autorestart=true
-"""
-    create_programs_conf_file(service_path, programs_config)
 
     args = Namespace(program_name="worker")
 
@@ -254,7 +241,7 @@ def test_foreground_programs_conf_not_found(
 
     captured = capsys.readouterr()
     assert (
-        f"{Color.RED}Dependency 'worker' is not remote but is not defined in docker-compose services or programs file{Color.RESET}\n"
+        f"{Color.RED}Dependency 'worker' is not remote but is not defined in docker-compose services or x-programs{Color.RESET}\n"
         == captured.out
     )
 
@@ -328,19 +315,16 @@ def test_foreground_supervisor_config_error(
             },
             "modes": {"default": ["worker"]},
         },
+        "x-programs": {
+            "worker": {
+                "command": "python worker.py",
+            },
+        },
     }
 
     service_path = tmp_path / "example-service"
     create_config_file(service_path, config)
     os.chdir(service_path)
-
-    programs_config = """
-[program:worker]
-command=python worker.py
-autostart=true
-autorestart=true
-"""
-    create_programs_conf_file(service_path, programs_config)
 
     mock_get_program_command.side_effect = SupervisorConfigError("Program config error")
 
@@ -383,19 +367,16 @@ def test_foreground_pty_spawn_exception(
             },
             "modes": {"default": ["worker"]},
         },
+        "x-programs": {
+            "worker": {
+                "command": "python worker.py",
+            },
+        },
     }
 
     service_path = tmp_path / "example-service"
     create_config_file(service_path, config)
     os.chdir(service_path)
-
-    programs_config = """
-[program:worker]
-command=python worker.py
-autostart=true
-autorestart=true
-"""
-    create_programs_conf_file(service_path, programs_config)
 
     mock_pty_spawn.side_effect = OSError("Spawn failed")
 
@@ -437,19 +418,16 @@ def test_foreground_stop_process_exception(
             },
             "modes": {"default": ["worker"]},
         },
+        "x-programs": {
+            "worker": {
+                "command": "python worker.py",
+            },
+        },
     }
 
     service_path = tmp_path / "example-service"
     create_config_file(service_path, config)
     os.chdir(service_path)
-
-    programs_config = """
-[program:worker]
-command=python worker.py
-autostart=true
-autorestart=true
-"""
-    create_programs_conf_file(service_path, programs_config)
 
     mock_stop_process.side_effect = SupervisorProcessError("Stop process failed")
 
@@ -492,19 +470,16 @@ def test_foreground_start_process_exception(
             },
             "modes": {"default": ["worker"]},
         },
+        "x-programs": {
+            "worker": {
+                "command": "python worker.py",
+            },
+        },
     }
 
     service_path = tmp_path / "example-service"
     create_config_file(service_path, config)
     os.chdir(service_path)
-
-    programs_config = """
-[program:worker]
-command=python worker.py
-autostart=true
-autorestart=true
-"""
-    create_programs_conf_file(service_path, programs_config)
 
     mock_start_process.side_effect = SupervisorProcessError("Start process failed")
 
@@ -547,19 +522,16 @@ def test_foreground_with_starting_services(
             },
             "modes": {"default": ["worker"]},
         },
+        "x-programs": {
+            "worker": {
+                "command": "python worker.py",
+            },
+        },
     }
 
     service_path = tmp_path / "example-service"
     create_config_file(service_path, config)
     os.chdir(service_path)
-
-    programs_config = """
-[program:worker]
-command=python worker.py
-autostart=true
-autorestart=true
-"""
-    create_programs_conf_file(service_path, programs_config)
 
     args = Namespace(program_name="worker")
 
@@ -608,6 +580,14 @@ def test_foreground_multiple_modes_and_dependencies(
                 "full": ["redis", "postgres", "worker", "consumer"],
             },
         },
+        "x-programs": {
+            "worker": {
+                "command": "python worker.py",
+            },
+            "consumer": {
+                "command": "python consumer.py",
+            },
+        },
         "services": {
             "redis": {"image": "redis:6.2.14-alpine"},
             "postgres": {"image": "postgres:13"},
@@ -617,19 +597,6 @@ def test_foreground_multiple_modes_and_dependencies(
     service_path = tmp_path / "example-service"
     create_config_file(service_path, config)
     os.chdir(service_path)
-
-    programs_config = """
-[program:worker]
-command=python worker.py
-autostart=true
-autorestart=true
-
-[program:consumer]
-command=python consumer.py
-autostart=true
-autorestart=true
-"""
-    create_programs_conf_file(service_path, programs_config)
 
     args = Namespace(program_name="consumer")
 
@@ -668,19 +635,16 @@ def test_foreground_no_active_modes(
             },
             "modes": {"default": ["worker"], "other": []},
         },
+        "x-programs": {
+            "worker": {
+                "command": "python worker.py",
+            },
+        },
     }
 
     service_path = tmp_path / "example-service"
     create_config_file(service_path, config)
     os.chdir(service_path)
-
-    programs_config = """
-[program:worker]
-command=python worker.py
-autostart=true
-autorestart=true
-"""
-    create_programs_conf_file(service_path, programs_config)
 
     args = Namespace(program_name="worker")
 

--- a/tests/commands/test_list_services.py
+++ b/tests/commands/test_list_services.py
@@ -161,7 +161,7 @@ def test_list_running_services_config_error(
 
         assert (
             captured.out
-            == "\x1b[0;33mexample-service was found with an invalid config\x1b[0m\n\x1b[0;31mDependency 'clickhouse' is not remote but is not defined in docker-compose services or programs file\x1b[0m\n"
+            == "\x1b[0;33mexample-service was found with an invalid config\x1b[0m\n\x1b[0;31mDependency 'clickhouse' is not remote but is not defined in docker-compose services or x-programs\x1b[0m\n"
         )
 
 

--- a/tests/commands/test_serve.py
+++ b/tests/commands/test_serve.py
@@ -9,6 +9,7 @@ from unittest.mock import patch
 import pytest
 
 from devservices.commands.serve import serve
+from devservices.constants import Color
 from devservices.constants import CONFIG_FILE_NAME
 from devservices.constants import DEVSERVICES_DIR_NAME
 from testing.utils import create_config_file
@@ -86,7 +87,7 @@ def test_serve_devservices_config_not_found(
     out, err = capsys.readouterr()
     assert (
         out
-        == "\x1b[0;31mUnable to bring up devserver due to supervisor config error: No x-programs block found in config.yml\x1b[0m\n"
+        == f"{Color.RED}No programs found in config. Please add the devserver in the `x-programs` block to your config.yml{Color.RESET}\n"
     )
     mock_pty_spawn.assert_not_called()
 
@@ -108,7 +109,7 @@ def test_serve_programs_conf_not_found(
     out, err = capsys.readouterr()
     assert (
         out
-        == f"\x1b[0;31mNo devservices configuration found in {service_path}/{DEVSERVICES_DIR_NAME}/{CONFIG_FILE_NAME}. Please run the command from a directory with a valid devservices configuration.\x1b[0m\n"
+        == f"{Color.RED}No devservices configuration found in {service_path}/{DEVSERVICES_DIR_NAME}/{CONFIG_FILE_NAME}. Please run the command from a directory with a valid devservices configuration.{Color.RESET}\n"
     )
     mock_pty_spawn.assert_not_called()
 
@@ -152,6 +153,6 @@ def test_serve_devserver_command_not_found(
     out, err = capsys.readouterr()
     assert (
         out
-        == "\x1b[0;31mError when getting devserver command: Program devserver not found in config\x1b[0m\n"
+        == f"{Color.RED}Error when getting devserver command: Program devserver not found in config{Color.RESET}\n"
     )
     mock_pty_spawn.assert_not_called()

--- a/tests/commands/test_serve.py
+++ b/tests/commands/test_serve.py
@@ -84,7 +84,10 @@ def test_serve_devservices_config_not_found(
     serve(args)
 
     out, err = capsys.readouterr()
-    assert out == "\x1b[0;31mNo x-programs block found in config.yml.\x1b[0m\n"
+    assert (
+        out
+        == "\x1b[0;31mUnable to bring up devserver due to supervisor config error: No x-programs block found in config.yml\x1b[0m\n"
+    )
     mock_pty_spawn.assert_not_called()
 
 


### PR DESCRIPTION
This moves previous programs.conf file definitions to config.yml. It allows for us to abstract default settings away from the user while keeping the config file more simple

Example `x-programs` block in config.yml:

```
x-programs:
  devserver:
    command: sentry devserver
  taskworker:
    command: sentry run taskworker --autoreload
  taskworker-scheduler:
    command: sentry run taskworker-scheduler
```