### PR TITLE
chore(devservices): add 'dependencies' string within startup console logs

### DIFF
--- a/devservices/commands/up.py
+++ b/devservices/commands/up.py
@@ -98,14 +98,16 @@ def up(args: Namespace, existing_status: Status | None = None) -> None:
 
     with Status(
         lambda: (
-            console.warning(f"Starting '{service.name}' in mode: '{mode}'")
+            console.warning(f"Starting '{service.name}' dependencies in mode: '{mode}'")
             if existing_status is None
-            else existing_status.warning(f"Starting '{service.name}' in mode: '{mode}'")
+            else existing_status.warning(
+                f"Starting '{service.name}' dependencies in mode: '{mode}'"
+            )
         ),
         lambda: (
-            console.success(f"{service.name} started")
+            console.success(f"{service.name} dependencies started")
             if existing_status is None
-            else existing_status.success(f"{service.name} started")
+            else existing_status.success(f"{service.name} dependencies started")
         ),
     ) as status:
         local_runtime_dependency_names = set()
@@ -305,9 +307,9 @@ def bring_up_docker_compose_services(
     )
     # Set the environment variable for the local dependencies directory to be used by docker compose
     current_env = os.environ.copy()
-    current_env[
-        DEVSERVICES_DEPENDENCIES_CACHE_DIR_KEY
-    ] = relative_local_dependency_directory
+    current_env[DEVSERVICES_DEPENDENCIES_CACHE_DIR_KEY] = (
+        relative_local_dependency_directory
+    )
     dependency_graph = construct_dependency_graph(service, modes=modes)
     starting_order = dependency_graph.get_starting_order()
     sorted_remote_dependencies = sorted(

--- a/devservices/commands/up.py
+++ b/devservices/commands/up.py
@@ -307,9 +307,9 @@ def bring_up_docker_compose_services(
     )
     # Set the environment variable for the local dependencies directory to be used by docker compose
     current_env = os.environ.copy()
-    current_env[DEVSERVICES_DEPENDENCIES_CACHE_DIR_KEY] = (
-        relative_local_dependency_directory
-    )
+    current_env[
+        DEVSERVICES_DEPENDENCIES_CACHE_DIR_KEY
+    ] = relative_local_dependency_directory
     dependency_graph = construct_dependency_graph(service, modes=modes)
     starting_order = dependency_graph.get_starting_order()
     sorted_remote_dependencies = sorted(

--- a/tests/commands/test_up.py
+++ b/tests/commands/test_up.py
@@ -170,7 +170,10 @@ def test_up_simple(
         mock_check_all_containers_healthy.assert_called_once()
         captured = capsys.readouterr()
         assert "Retrieving dependencies" in captured.out.strip()
-        assert "Starting 'example-service' in mode: 'default'" in captured.out.strip()
+        assert (
+            "Starting 'example-service' dependencies in mode: 'default'"
+            in captured.out.strip()
+        )
         assert "Starting clickhouse" in captured.out.strip()
         assert "Starting redis" in captured.out.strip()
 
@@ -238,7 +241,8 @@ def test_up_dependency_error(
         captured = capsys.readouterr()
         assert "Retrieving dependencies" not in captured.out.strip()
         assert (
-            "Starting 'example-service' in mode: 'default'" not in captured.out.strip()
+            "Starting 'example-service' dependencies in mode: 'default'"
+            not in captured.out.strip()
         )
         assert "Starting clickhouse" not in captured.out.strip()
         assert "Starting redis" not in captured.out.strip()
@@ -348,7 +352,10 @@ def test_up_error(
     mock_remove_service_entry.assert_not_called()
 
     assert "Retrieving dependencies" in captured.out.strip()
-    assert "Starting 'example-service' in mode: 'default'" in captured.out.strip()
+    assert (
+        "Starting 'example-service' dependencies in mode: 'default'"
+        in captured.out.strip()
+    )
     assert "Starting clickhouse" not in captured.out.strip()
     assert "Starting redis" not in captured.out.strip()
 
@@ -564,7 +571,7 @@ def test_up_pull_error_eventual_success(
     mock_create_devservices_network.assert_called_once()
     captured = capsys.readouterr()
 
-    assert "example-service started" in captured.out.strip()
+    assert "example-service dependencies started" in captured.out.strip()
 
 
 @mock.patch("devservices.utils.state.State.remove_service_entry")
@@ -704,7 +711,10 @@ def test_up_docker_compose_container_lookup_error(
         mock_check_all_containers_healthy.assert_not_called()
         captured = capsys.readouterr()
         assert "Retrieving dependencies" in captured.out.strip()
-        assert "Starting 'example-service' in mode: 'default'" in captured.out.strip()
+        assert (
+            "Starting 'example-service' dependencies in mode: 'default'"
+            in captured.out.strip()
+        )
         assert "Starting clickhouse" in captured.out.strip()
         assert "Starting redis" in captured.out.strip()
         assert (
@@ -848,7 +858,10 @@ def test_up_docker_compose_container_healthcheck_failed(
         mock_check_all_containers_healthy.assert_called_once()
         captured = capsys.readouterr()
         assert "Retrieving dependencies" in captured.out.strip()
-        assert "Starting 'example-service' in mode: 'default'" in captured.out.strip()
+        assert (
+            "Starting 'example-service' dependencies in mode: 'default'"
+            in captured.out.strip()
+        )
         assert "Starting clickhouse" in captured.out.strip()
         assert "Starting redis" in captured.out.strip()
         assert (
@@ -993,7 +1006,10 @@ def test_up_mode_simple(
         assert (
             "Starting dependencies with local runtimes..." not in captured.out.strip()
         ), "This shouldn't be printed since we don't have any dependencies with local runtimes"
-        assert "Starting 'example-service' in mode: 'test'" in captured.out.strip()
+        assert (
+            "Starting 'example-service' dependencies in mode: 'test'"
+            in captured.out.strip()
+        )
         assert "Starting redis" in captured.out.strip()
 
 
@@ -1079,7 +1095,10 @@ def test_up_mode_does_not_exist(
         assert (
             "Starting dependencies with local runtimes..." not in captured.out.strip()
         ), "This shouldn't be printed since we don't have any dependencies with local runtimes"
-        assert "Starting 'example-service' in mode: 'test'" not in captured.out.strip()
+        assert (
+            "Starting 'example-service' dependencies in mode: 'test'"
+            not in captured.out.strip()
+        )
         assert "Starting clickhouse" not in captured.out.strip()
         assert "Starting redis" not in captured.out.strip()
 
@@ -1184,7 +1203,10 @@ def test_up_multiple_modes(
         mock_check_all_containers_healthy.assert_called_once()
 
         captured = capsys.readouterr()
-        assert "Starting 'example-service' in mode: 'test'" in captured.out.strip()
+        assert (
+            "Starting 'example-service' dependencies in mode: 'test'"
+            in captured.out.strip()
+        )
         assert (
             "Starting dependencies with local runtimes..." not in captured.out.strip()
         ), "This shouldn't be printed since we don't have any dependencies with local runtimes"
@@ -1351,7 +1373,10 @@ def test_up_multiple_modes_overlapping_running_service(
         )
 
         captured = capsys.readouterr()
-        assert "Starting 'example-service' in mode: 'test'" in captured.out.strip()
+        assert (
+            "Starting 'example-service' dependencies in mode: 'test'"
+            in captured.out.strip()
+        )
         assert "Retrieving dependencies" in captured.out.strip()
         assert (
             "Starting dependencies with local runtimes..." not in captured.out.strip()
@@ -2522,7 +2547,10 @@ def test_up_supervisor_program(
         assert (
             "Starting dependencies with local runtimes..." not in captured.out.strip()
         ), "This shouldn't be printed since we don't have any dependencies with local runtimes"
-        assert "Starting 'example-service' in mode: 'default'" in captured.out.strip()
+        assert (
+            "Starting 'example-service' dependencies in mode: 'default'"
+            in captured.out.strip()
+        )
         assert "Starting supervisor daemon" in captured.out.strip()
         assert "Starting supervisor-program" in captured.out.strip()
 
@@ -2615,7 +2643,10 @@ def test_up_supervisor_program_error(
         assert (
             "Starting dependencies with local runtimes..." not in captured.out.strip()
         ), "This shouldn't be printed since we don't have any dependencies with local runtimes"
-        assert "Starting 'example-service' in mode: 'default'" in captured.out.strip()
+        assert (
+            "Starting 'example-service' dependencies in mode: 'default'"
+            in captured.out.strip()
+        )
         assert "Starting supervisor daemon" in captured.out.strip()
         assert "Error starting supervisor daemon" in captured.out.strip()
 


### PR DESCRIPTION
This is a biased suggestion, but when I read the startup console logs:

```
Starting 'launchpad' in mode: 'default'
Retrieving dependencies
Pulling images
Pulled image for kafka
Starting kafka
Waiting for all containers to be healthy
kafka is healthy
launchpad started
```

it's not launchpad that is starting but rather launchpad's dependencies