### PR TITLE
feat(logging): Add some basic logs

### DIFF
--- a/devservices/commands/down.py
+++ b/devservices/commands/down.py
@@ -119,7 +119,7 @@ def down(args: Namespace) -> None:
     ]
 
     logger = logging.getLogger(LOGGER_NAME)
-    logger.info(
+    logger.debug(
         "Stopping service",
         extra={
             "service_name": service.name,

--- a/devservices/commands/down.py
+++ b/devservices/commands/down.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import concurrent.futures
+import logging
 import os
 import subprocess
 from argparse import _SubParsersAction
@@ -15,6 +16,7 @@ from devservices.constants import DependencyType
 from devservices.constants import DEVSERVICES_DEPENDENCIES_CACHE_DIR
 from devservices.constants import DEVSERVICES_DEPENDENCIES_CACHE_DIR_KEY
 from devservices.constants import DEVSERVICES_DIR_NAME
+from devservices.constants import LOGGER_NAME
 from devservices.exceptions import ConfigError
 from devservices.exceptions import ConfigNotFoundError
 from devservices.exceptions import DependencyError
@@ -115,6 +117,16 @@ def down(args: Namespace) -> None:
         and service.config.dependencies[dep].dependency_type
         == DependencyType.SUPERVISOR
     ]
+
+    logger = logging.getLogger(LOGGER_NAME)
+    logger.info(
+        "Stopping service",
+        extra={
+            "service_name": service.name,
+            "exclude_local": exclude_local,
+            "mode": list(active_modes),
+        },
+    )
 
     with Status(
         lambda: console.warning(f"Stopping {service.name}"),

--- a/devservices/commands/down.py
+++ b/devservices/commands/down.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import concurrent.futures
-import logging
 import os
 import subprocess
 from argparse import _SubParsersAction
@@ -9,6 +8,7 @@ from argparse import ArgumentParser
 from argparse import Namespace
 
 from sentry_sdk import capture_exception
+from sentry_sdk import logger as sentry_logger
 
 from devservices.constants import CONFIG_FILE_NAME
 from devservices.constants import DEPENDENCY_CONFIG_VERSION
@@ -16,7 +16,6 @@ from devservices.constants import DependencyType
 from devservices.constants import DEVSERVICES_DEPENDENCIES_CACHE_DIR
 from devservices.constants import DEVSERVICES_DEPENDENCIES_CACHE_DIR_KEY
 from devservices.constants import DEVSERVICES_DIR_NAME
-from devservices.constants import LOGGER_NAME
 from devservices.exceptions import ConfigError
 from devservices.exceptions import ConfigNotFoundError
 from devservices.exceptions import DependencyError
@@ -118,8 +117,7 @@ def down(args: Namespace) -> None:
         == DependencyType.SUPERVISOR
     ]
 
-    logger = logging.getLogger(LOGGER_NAME)
-    logger.debug(
+    sentry_logger.info(
         "Stopping service",
         extra={
             "service_name": service.name,

--- a/devservices/commands/down.py
+++ b/devservices/commands/down.py
@@ -124,7 +124,7 @@ def down(args: Namespace) -> None:
         extra={
             "service_name": service.name,
             "exclude_local": exclude_local,
-            "mode": list(active_modes),
+            "active_modes": list(active_modes),
         },
     )
 

--- a/devservices/commands/up.py
+++ b/devservices/commands/up.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import concurrent.futures
+import logging
 import os
 import subprocess
 from argparse import _SubParsersAction
@@ -17,6 +18,7 @@ from devservices.constants import DependencyType
 from devservices.constants import DEVSERVICES_DEPENDENCIES_CACHE_DIR
 from devservices.constants import DEVSERVICES_DEPENDENCIES_CACHE_DIR_KEY
 from devservices.constants import DEVSERVICES_DIR_NAME
+from devservices.constants import LOGGER_NAME
 from devservices.exceptions import ConfigError
 from devservices.exceptions import ConfigNotFoundError
 from devservices.exceptions import ContainerHealthcheckFailedError
@@ -93,6 +95,17 @@ def up(args: Namespace, existing_status: Status | None = None) -> None:
     modes = service.config.modes
     mode = args.mode
     exclude_local = getattr(args, "exclude_local", False)
+
+    logger = logging.getLogger(LOGGER_NAME)
+    logger.info(
+        "Starting service",
+        extra={
+            "service_name": service.name,
+            "mode": mode,
+            "exclude_local": exclude_local,
+            "available_modes": list(modes.keys()),
+        },
+    )
 
     state = State()
 

--- a/devservices/commands/up.py
+++ b/devservices/commands/up.py
@@ -97,7 +97,7 @@ def up(args: Namespace, existing_status: Status | None = None) -> None:
     exclude_local = getattr(args, "exclude_local", False)
 
     logger = logging.getLogger(LOGGER_NAME)
-    logger.info(
+    logger.debug(
         "Starting service",
         extra={
             "service_name": service.name,

--- a/devservices/commands/up.py
+++ b/devservices/commands/up.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 
 import concurrent.futures
-import logging
 import os
 import subprocess
 from argparse import _SubParsersAction
@@ -9,6 +8,7 @@ from argparse import ArgumentParser
 from argparse import Namespace
 
 from sentry_sdk import capture_exception
+from sentry_sdk import logger as sentry_logger
 from sentry_sdk import set_context
 from sentry_sdk import start_span
 
@@ -18,7 +18,6 @@ from devservices.constants import DependencyType
 from devservices.constants import DEVSERVICES_DEPENDENCIES_CACHE_DIR
 from devservices.constants import DEVSERVICES_DEPENDENCIES_CACHE_DIR_KEY
 from devservices.constants import DEVSERVICES_DIR_NAME
-from devservices.constants import LOGGER_NAME
 from devservices.exceptions import ConfigError
 from devservices.exceptions import ConfigNotFoundError
 from devservices.exceptions import ContainerHealthcheckFailedError
@@ -96,8 +95,7 @@ def up(args: Namespace, existing_status: Status | None = None) -> None:
     mode = args.mode
     exclude_local = getattr(args, "exclude_local", False)
 
-    logger = logging.getLogger(LOGGER_NAME)
-    logger.debug(
+    sentry_logger.info(
         "Starting service",
         extra={
             "service_name": service.name,

--- a/devservices/main.py
+++ b/devservices/main.py
@@ -16,6 +16,7 @@ from sentry_sdk import set_tag
 from sentry_sdk import set_user
 from sentry_sdk import start_transaction
 from sentry_sdk.integrations.argv import ArgvIntegration
+from sentry_sdk.integrations.logging import LoggingIntegration
 from sentry_sdk.types import Event
 from sentry_sdk.types import Hint
 
@@ -79,7 +80,11 @@ if not disable_sentry:
         dsn="https://56470da7302c16e83141f62f88e46449@o1.ingest.us.sentry.io/4507946704961536",
         traces_sample_rate=1.0,
         profiles_sample_rate=1.0,
-        integrations=[ArgvIntegration()],
+        integrations=[
+            ArgvIntegration(),
+            LoggingIntegration(sentry_logs_level=logging.DEBUG),
+        ],
+        enable_logs=True,
         environment=sentry_environment,
         before_send=before_send_error,
         before_send_transaction=before_send_transaction,

--- a/devservices/utils/dependencies.py
+++ b/devservices/utils/dependencies.py
@@ -411,10 +411,21 @@ def install_dependencies(
 
 
 def install_dependency(dependency: RemoteConfig) -> set[InstalledRemoteDependency]:
+    logger = logging.getLogger(LOGGER_NAME)
     dependency_repo_dir = os.path.join(
         DEVSERVICES_DEPENDENCIES_CACHE_DIR,
         DEPENDENCY_CONFIG_VERSION,
         dependency.repo_name,
+    )
+
+    logger.info(
+        "Installing dependency",
+        extra={
+            "repo_name": dependency.repo_name,
+            "repo_link": dependency.repo_link,
+            "branch": dependency.branch,
+            "mode": dependency.mode,
+        },
     )
 
     os.makedirs(DEVSERVICES_DEPENDENCIES_CACHE_DIR, exist_ok=True)
@@ -498,6 +509,15 @@ def _update_dependency(
     dependency: RemoteConfig,
     dependency_repo_dir: str,
 ) -> None:
+    logger = logging.getLogger(LOGGER_NAME)
+    logger.info(
+        "Updating dependency",
+        extra={
+            "repo_name": dependency.repo_name,
+            "repo_link": dependency.repo_link,
+            "branch": dependency.branch,
+        },
+    )
     git_config_manager = GitConfigManager(
         dependency_repo_dir,
         DEPENDENCY_GIT_PARTIAL_CLONE_CONFIG_OPTIONS,
@@ -580,6 +600,15 @@ def _checkout_dependency(
     dependency: RemoteConfig,
     dependency_repo_dir: str,
 ) -> None:
+    logger = logging.getLogger(LOGGER_NAME)
+    logger.info(
+        "Checking out dependency",
+        extra={
+            "repo_name": dependency.repo_name,
+            "repo_link": dependency.repo_link,
+            "branch": dependency.branch,
+        },
+    )
     with tempfile.TemporaryDirectory() as temp_dir:
         try:
             _run_command(

--- a/devservices/utils/dependencies.py
+++ b/devservices/utils/dependencies.py
@@ -14,6 +14,7 @@ from typing import TextIO
 from typing import TypeGuard
 
 from sentry_sdk import capture_message
+from sentry_sdk import logger as sentry_logger
 from sentry_sdk import set_context
 
 from devservices.configs.service_config import Dependency
@@ -411,14 +412,13 @@ def install_dependencies(
 
 
 def install_dependency(dependency: RemoteConfig) -> set[InstalledRemoteDependency]:
-    logger = logging.getLogger(LOGGER_NAME)
     dependency_repo_dir = os.path.join(
         DEVSERVICES_DEPENDENCIES_CACHE_DIR,
         DEPENDENCY_CONFIG_VERSION,
         dependency.repo_name,
     )
 
-    logger.debug(
+    sentry_logger.info(
         "Installing dependency",
         extra={
             "repo_name": dependency.repo_name,
@@ -509,8 +509,7 @@ def _update_dependency(
     dependency: RemoteConfig,
     dependency_repo_dir: str,
 ) -> None:
-    logger = logging.getLogger(LOGGER_NAME)
-    logger.debug(
+    sentry_logger.info(
         "Updating dependency",
         extra={
             "repo_name": dependency.repo_name,
@@ -600,8 +599,7 @@ def _checkout_dependency(
     dependency: RemoteConfig,
     dependency_repo_dir: str,
 ) -> None:
-    logger = logging.getLogger(LOGGER_NAME)
-    logger.debug(
+    sentry_logger.info(
         "Checking out dependency",
         extra={
             "repo_name": dependency.repo_name,

--- a/devservices/utils/dependencies.py
+++ b/devservices/utils/dependencies.py
@@ -418,7 +418,7 @@ def install_dependency(dependency: RemoteConfig) -> set[InstalledRemoteDependenc
         dependency.repo_name,
     )
 
-    logger.info(
+    logger.debug(
         "Installing dependency",
         extra={
             "repo_name": dependency.repo_name,
@@ -510,7 +510,7 @@ def _update_dependency(
     dependency_repo_dir: str,
 ) -> None:
     logger = logging.getLogger(LOGGER_NAME)
-    logger.info(
+    logger.debug(
         "Updating dependency",
         extra={
             "repo_name": dependency.repo_name,
@@ -601,7 +601,7 @@ def _checkout_dependency(
     dependency_repo_dir: str,
 ) -> None:
     logger = logging.getLogger(LOGGER_NAME)
-    logger.info(
+    logger.debug(
         "Checking out dependency",
         extra={
             "repo_name": dependency.repo_name,

--- a/devservices/utils/docker_compose.py
+++ b/devservices/utils/docker_compose.py
@@ -306,7 +306,7 @@ def run_cmd(
     console = Console()
     cmd_pretty = shlex.join(cmd)
 
-    logger.info(
+    logger.debug(
         "Running docker compose command",
         extra={
             "command": cmd_pretty,

--- a/devservices/utils/docker_compose.py
+++ b/devservices/utils/docker_compose.py
@@ -306,6 +306,14 @@ def run_cmd(
     console = Console()
     cmd_pretty = shlex.join(cmd)
 
+    logger.info(
+        "Running docker compose command",
+        extra={
+            "command": cmd_pretty,
+            "max_retries": retries,
+        },
+    )
+
     proc = None
     retries += 1  # initial try
 

--- a/devservices/utils/docker_compose.py
+++ b/devservices/utils/docker_compose.py
@@ -12,6 +12,7 @@ from typing import cast
 from typing import NamedTuple
 
 from packaging import version
+from sentry_sdk import logger as sentry_logger
 
 from devservices.configs.service_config import load_service_config_from_file
 from devservices.constants import CONFIG_FILE_NAME
@@ -306,7 +307,7 @@ def run_cmd(
     console = Console()
     cmd_pretty = shlex.join(cmd)
 
-    logger.debug(
+    sentry_logger.info(
         "Running docker compose command",
         extra={
             "command": cmd_pretty,

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@
 pyyaml==6.0.2
 packaging==24.0
 sentry-devenv==1.9.0
-sentry-sdk==2.27.0
+sentry-sdk==2.39.0
 supervisor==4.2.5


### PR DESCRIPTION
This adds some basic logs, since we should dogfood our own product.

example logs: https://sentry.sentry.io/explore/logs/?guidedStep=3&logsFields=timestamp&logsFields=message&logsSortBys=-timestamp&project=4507946704961536&statsPeriod=30d