### PR TITLE
fix: ignore_cleanup_errors to mitigate strange flakes in sentry CI

### DIFF
--- a/devservices/utils/dependencies.py
+++ b/devservices/utils/dependencies.py
@@ -605,7 +605,7 @@ def _checkout_dependency(
             "branch": dependency.branch,
         },
     )
-    with tempfile.TemporaryDirectory() as temp_dir:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
         try:
             _run_command(
                 [

--- a/devservices/utils/install_binary.py
+++ b/devservices/utils/install_binary.py
@@ -18,7 +18,7 @@ def install_binary(
     url: str,
 ) -> None:
     console = Console()
-    with tempfile.TemporaryDirectory() as temp_dir:
+    with tempfile.TemporaryDirectory(ignore_cleanup_errors=True) as temp_dir:
         temp_file = os.path.join(temp_dir, binary_name)
 
         # Download the binary with retries


### PR DESCRIPTION
edit: here's a failing job https://github.com/getsentry/sentry/actions/runs/25004348752/job/73222906040 which is using runner version 20260426.100

https://github.com/actions/runner-images/releases/tag/ubuntu24/20260426.100

git got upgraded to 2.54.0

claude says: Git 2.54.0's geometric repacking default means
   gc.auto (which fires in the background after fetch/clone) now creates more
   files in .git/objects/pack/ — MIDX layers, bitmap files, incremental packs
   — compared to 2.53.0. If this background gc process creates any of those
  files after Python's shutil.rmtree has already scanned the directory but
  before the final os.rmdir('.git'), you get ENOTEMPTY. The race window is
  small, hence the flakiness rather than consistent failure.

---

not really sure what's going on here but my best guess is github upgraded/reconfigured git on their runner images to do more background repo bookkeeping stuff and that's racing with python's tempdir cleanup

mitigate this; it's not a symptom of anything bad happening, and it's fine if the dirs aren't completely cleaned up since it's part of an ephemeral job anyway
