### PR TITLE
fix: disable git auto-gc during dependency temp-dir clone+checkout

### DIFF
--- a/devservices/utils/dependencies.py
+++ b/devservices/utils/dependencies.py
@@ -610,6 +610,12 @@ def _checkout_dependency(
             _run_command(
                 [
                     "git",
+                    "-c",
+                    "gc.auto=0",
+                    "-c",
+                    "maintenance.auto=false",
+                    "-c",
+                    "fetch.writeCommitGraph=false",
                     "clone",
                     "--filter=blob:none",
                     "--no-checkout",
@@ -643,7 +649,17 @@ def _checkout_dependency(
 
         try:
             _run_command(
-                ["git", "checkout", dependency.branch],
+                [
+                    "git",
+                    "-c",
+                    "gc.auto=0",
+                    "-c",
+                    "maintenance.auto=false",
+                    "-c",
+                    "fetch.writeCommitGraph=false",
+                    "checkout",
+                    dependency.branch,
+                ],
                 cwd=temp_dir,
             )
         except subprocess.CalledProcessError as e:

--- a/tests/utils/test_dependencies.py
+++ b/tests/utils/test_dependencies.py
@@ -389,6 +389,12 @@ def test_install_dependency_git_clone_failure(
         mock_run_command.assert_called_once_with(
             [
                 "git",
+                "-c",
+                "gc.auto=0",
+                "-c",
+                "maintenance.auto=false",
+                "-c",
+                "fetch.writeCommitGraph=false",
                 "clone",
                 "--filter=blob:none",
                 "--no-checkout",
@@ -449,6 +455,12 @@ def test_install_dependency_git_checkout_failure(
                 mock.call(
                     [
                         "git",
+                        "-c",
+                        "gc.auto=0",
+                        "-c",
+                        "maintenance.auto=false",
+                        "-c",
+                        "fetch.writeCommitGraph=false",
                         "clone",
                         "--filter=blob:none",
                         "--no-checkout",
@@ -460,6 +472,12 @@ def test_install_dependency_git_checkout_failure(
                 mock.call(
                     [
                         "git",
+                        "-c",
+                        "gc.auto=0",
+                        "-c",
+                        "maintenance.auto=false",
+                        "-c",
+                        "fetch.writeCommitGraph=false",
                         "checkout",
                         "main",
                     ],


### PR DESCRIPTION
We're seeing intermittent acceptance failures on getsentry/sentry where `devservices up` blows up with `shutil.Error` from `_checkout_dependency`. Attempt 1 of run 25064611924 / job 73428191911:

```
File ".../devservices/utils/dependencies.py", line 662, in _checkout_dependency
    shutil.copytree(temp_dir, dst=dependency_repo_dir)
shutil.Error: [('/tmp/tmpoydmzhs4/.git/objects/info/commit-graphs/tmp_graph_8REK9p',
                '.../chartcuterie/.git/objects/info/commit-graphs/tmp_graph_8REK9p',
                "[Errno 2] No such file or directory: '/tmp/tmpoydmzhs4/.git/objects/info/commit-graphs/tmp_graph_8REK9p'")]
```

The same job logs `git version 2.54.0`, and 2.54.0's release notes call out that `git maintenance` now defaults to the geometric strategy. The new default writes more `tmp_graph_*` and `commit-graph-chain.lock` fragments via the create-then-rename pattern git uses for atomic commit-graph chain updates. After our `git checkout` returns, `gc.auto` fires in the background and starts writing those fragments while `copytree` is still walking the temp tree: `os.scandir` enumerates a tmp file, then `shutil.copy2` hits `ENOENT` because git has already renamed it.

Fundamentally none of this background bookkeeping is useful inside a temp dir we're about to bulk-copy: any work either gets carried over verbatim during `copytree` or redone later when the cache is actually used. #312 patched a related race in `TemporaryDirectory`'s implicit cleanup (the `rmtree` when the `with` block exits), but `copytree` doesn't go through that cleanup machinery so `ignore_cleanup_errors=True` doesn't apply here. We disable auto-gc on the two git invocations inside the temp dir (the partial clone and the checkout) by passing `-c gc.auto=0 -c maintenance.auto=false -c fetch.writeCommitGraph=false`. That stops the background gc from ever running against the temp dir, killing both this `copytree` race and the `rmtree` race #312 was patching around.

(Considered also adding `ignore=shutil.ignore_patterns('tmp_*', '*.lock')` to the `copytree` as belt-and-suspenders, but disabling gc at the source is the cleaner fix; the patterns approach would still have a residual race for any non-tmp file that maintenance might touch.)