### PR TITLE
fix(up): serialize container startup to avoid concurrent compose deadlock

### DIFF
--- a/devservices/commands/up.py
+++ b/devservices/commands/up.py
@@ -367,16 +367,10 @@ def bring_up_docker_compose_services(
         mode_dependencies=mode_dependencies,
     )
 
+    # Serial: concurrent `up` can deadlock attaching to the shared network.
     containers_to_check = []
-    with concurrent.futures.ThreadPoolExecutor() as up_dependency_executor:
-        futures = [
-            up_dependency_executor.submit(
-                _bring_up_dependency, cmd, current_env, status
-            )
-            for cmd in up_commands
-        ]
-        for future in concurrent.futures.as_completed(futures):
-            _ = future.result()
+    for cmd in up_commands:
+        _bring_up_dependency(cmd, current_env, status)
 
     for cmd in up_commands:
         try:


### PR DESCRIPTION
Backend CI shards intermittently hang in `devservices up` after pulling images, with zero containers ever created, then fail on the downstream wait timeout. The cause is the concurrent `docker compose up -d` calls deadlocking as they attach containers to the shared `devservices` network at the same time. We bring the projects up serially instead (image pulls and health checks still run in parallel), which removes the race for a negligible time cost since `up -d` only creates and starts containers.