### PR TITLE
fix: authed zip downloads

### DIFF
--- a/devservices/utils/dependencies.py
+++ b/devservices/utils/dependencies.py
@@ -30,6 +30,7 @@ from devservices.exceptions import DependencyError
 from devservices.exceptions import DependencyNotInstalledError
 from devservices.exceptions import InvalidDependencyConfigError
 from devservices.exceptions import ModeDoesNotExistError
+from devservices.utils import github
 from devservices.utils.file_lock import lock
 from devservices.utils.retry import retry
 from devservices.utils.services import Service
@@ -398,13 +399,6 @@ def install_dependency(dependency: RemoteConfig) -> set[InstalledRemoteDependenc
     return installed_dependencies
 
 
-def _parse_github_repo_path(repo_link: str) -> str:
-    url = repo_link.rstrip("/").removesuffix(".git")
-    if "github.com/" not in url:
-        raise ValueError(f"Not a GitHub URL: {repo_link}")
-    return url.split("github.com/", 1)[1]
-
-
 def _fetch_dependency(
     dependency: RemoteConfig,
     dependency_repo_dir: str,
@@ -418,7 +412,7 @@ def _fetch_dependency(
         },
     )
     try:
-        repo_path = _parse_github_repo_path(dependency.repo_link)
+        repo_path = github.parse_repo_path(dependency.repo_link)
     except ValueError as e:
         raise DependencyError(
             repo_name=dependency.repo_name,
@@ -426,15 +420,8 @@ def _fetch_dependency(
             branch=dependency.branch,
         ) from e
 
-    zip_url = f"https://api.github.com/repos/{repo_path}/zipball/{dependency.branch}"
-
-    headers = {"Accept": "application/vnd.github+json"}
-    # Authenticate when a token is available so we get the 5000 req/hr limit
-    # instead of the 60 req/hr unauthenticated limit (which CI runners, sharing
-    # egress IPs, exhaust quickly and then receive HTTP 403s).
-    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
-    if token:
-        headers["Authorization"] = f"Bearer {token}"
+    zip_url = github.zipball_url(repo_path, dependency.branch)
+    headers = github.api_headers()
 
     def _download() -> bytes:
         req = urllib.request.Request(zip_url, headers=headers)

--- a/devservices/utils/dependencies.py
+++ b/devservices/utils/dependencies.py
@@ -421,10 +421,9 @@ def _fetch_dependency(
         ) from e
 
     zip_url = github.zipball_url(repo_path, dependency.branch)
-    headers = github.api_headers()
 
     def _download() -> bytes:
-        req = urllib.request.Request(zip_url, headers=headers)
+        req = github.build_api_request(zip_url)
         with urllib.request.urlopen(req) as response:
             return bytes(response.read())
 

--- a/devservices/utils/dependencies.py
+++ b/devservices/utils/dependencies.py
@@ -428,11 +428,16 @@ def _fetch_dependency(
 
     zip_url = f"https://api.github.com/repos/{repo_path}/zipball/{dependency.branch}"
 
+    headers = {"Accept": "application/vnd.github+json"}
+    # Authenticate when a token is available so we get the 5000 req/hr limit
+    # instead of the 60 req/hr unauthenticated limit (which CI runners, sharing
+    # egress IPs, exhaust quickly and then receive HTTP 403s).
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+
     def _download() -> bytes:
-        req = urllib.request.Request(
-            zip_url,
-            headers={"Accept": "application/vnd.github+json"},
-        )
+        req = urllib.request.Request(zip_url, headers=headers)
         with urllib.request.urlopen(req) as response:
             return bytes(response.read())
 

--- a/devservices/utils/github.py
+++ b/devservices/utils/github.py
@@ -1,0 +1,84 @@
+from __future__ import annotations
+
+import os
+import shutil
+import subprocess
+import sys
+import threading
+
+from devservices.utils.console import Console
+
+GITHUB_API_ACCEPT = "application/vnd.github+json"
+
+_auth_warning_lock = threading.Lock()
+_auth_warned = False
+
+
+def parse_repo_path(repo_link: str) -> str:
+    """Extract the "owner/repo" path from a GitHub URL."""
+    url = repo_link.rstrip("/").removesuffix(".git")
+    if "github.com/" not in url:
+        raise ValueError(f"Not a GitHub URL: {repo_link}")
+    return url.split("github.com/", 1)[1]
+
+
+def zipball_url(repo_path: str, ref: str) -> str:
+    return f"https://api.github.com/repos/{repo_path}/zipball/{ref}"
+
+
+def api_headers() -> dict[str, str]:
+    """Build request headers for the GitHub API, authenticating when possible.
+
+    Authenticated requests get the 5000 req/hr rate limit instead of the 60
+    req/hr unauthenticated limit (which CI runners, sharing egress IPs, exhaust
+    quickly and then receive HTTP 403s).
+    """
+    headers = {"Accept": GITHUB_API_ACCEPT}
+    token = _get_token()
+    if token:
+        headers["Authorization"] = f"Bearer {token}"
+    return headers
+
+
+def _get_token() -> str | None:
+    # Prefer an explicit token from the environment (CI sets these), otherwise
+    # fall back to the locally authenticated `gh` CLI so local users are authed
+    # without extra setup.
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if token:
+        return token
+    if shutil.which("gh") is not None:
+        try:
+            result = subprocess.run(
+                ["gh", "auth", "token"],
+                capture_output=True,
+                text=True,
+                timeout=5,
+            )
+        except (OSError, subprocess.SubprocessError):
+            result = None
+        if result is not None and result.returncode == 0:
+            token = result.stdout.strip()
+            if token:
+                return token
+    _warn_unauthenticated()
+    return None
+
+
+def _warn_unauthenticated() -> None:
+    # Fetches run concurrently across dependencies; only warn once per process so
+    # we don't spam the same message for every dependency.
+    global _auth_warned
+    with _auth_warning_lock:
+        if _auth_warned:
+            return
+        _auth_warned = True
+    if sys.platform == "darwin":
+        install_hint = "Install the GitHub CLI (brew install gh)"
+    else:
+        install_hint = "Install the GitHub CLI (https://github.com/cli/cli)"
+    Console().warning(
+        "Could not authenticate with GitHub; falling back to unauthenticated "
+        f"downloads, which are heavily rate-limited. {install_hint} and run "
+        "`gh auth login` to authenticate."
+    )

--- a/devservices/utils/github.py
+++ b/devservices/utils/github.py
@@ -5,6 +5,7 @@ import shutil
 import subprocess
 import sys
 import threading
+import urllib.request
 
 from devservices.utils.console import Console
 
@@ -26,18 +27,22 @@ def zipball_url(repo_path: str, ref: str) -> str:
     return f"https://api.github.com/repos/{repo_path}/zipball/{ref}"
 
 
-def api_headers() -> dict[str, str]:
-    """Build request headers for the GitHub API, authenticating when possible.
+def build_api_request(url: str) -> urllib.request.Request:
+    """Build an authenticated GitHub API request, authenticating when possible.
 
     Authenticated requests get the 5000 req/hr rate limit instead of the 60
     req/hr unauthenticated limit (which CI runners, sharing egress IPs, exhaust
     quickly and then receive HTTP 403s).
     """
-    headers = {"Accept": GITHUB_API_ACCEPT}
+    req = urllib.request.Request(url, headers={"Accept": GITHUB_API_ACCEPT})
     token = _get_token()
     if token:
-        headers["Authorization"] = f"Bearer {token}"
-    return headers
+        # Use an unredirected header so the token is only sent to api.github.com
+        # and is NOT forwarded when the API 302-redirects the download to
+        # codeload.github.com (and S3-backed hosts for other endpoints), which
+        # reject or mishandle requests that carry an Authorization header.
+        req.add_unredirected_header("Authorization", f"Bearer {token}")
+    return req
 
 
 def _get_token() -> str | None:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -38,6 +38,11 @@ devservices = "devservices.main:main"
 [tool.setuptools.packages]
 find = {}
 
+[tool.pytest.ini_options]
+markers = [
+    "integration: tests that hit real external services (run in CI only)",
+]
+
 [[tool.uv.index]]
 url = "https://pypi.devinfra.sentry.io/simple"
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -8,3 +8,19 @@ from devservices.utils.state import State
 @pytest.fixture(autouse=True)
 def clear_singleton_instance() -> None:
     State._instance = None
+
+
+@pytest.fixture(autouse=True)
+def deterministic_github_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Keep GitHub token resolution deterministic and offline.
+
+    Without this, any test that fetches a dependency would consult the ambient
+    GITHUB_TOKEN/GH_TOKEN env vars and shell out to the real `gh` CLI, which is
+    slow and varies between local and CI environments. Tests that exercise the
+    auth logic itself override these patches.
+    """
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.setattr("devservices.utils.github.shutil.which", lambda _: None)
+    # Treat the warning as already emitted so unauthenticated fetches stay quiet.
+    monkeypatch.setattr("devservices.utils.github._auth_warned", True)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -11,14 +11,20 @@ def clear_singleton_instance() -> None:
 
 
 @pytest.fixture(autouse=True)
-def deterministic_github_auth(monkeypatch: pytest.MonkeyPatch) -> None:
+def deterministic_github_auth(
+    request: pytest.FixtureRequest, monkeypatch: pytest.MonkeyPatch
+) -> None:
     """Keep GitHub token resolution deterministic and offline.
 
     Without this, any test that fetches a dependency would consult the ambient
     GITHUB_TOKEN/GH_TOKEN env vars and shell out to the real `gh` CLI, which is
     slow and varies between local and CI environments. Tests that exercise the
     auth logic itself override these patches.
+
+    Integration tests opt out so they can authenticate against real GitHub.
     """
+    if request.node.get_closest_marker("integration"):
+        return
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     monkeypatch.delenv("GH_TOKEN", raising=False)
     monkeypatch.setattr("devservices.utils.github.shutil.which", lambda _: None)

--- a/tests/utils/test_dependencies.py
+++ b/tests/utils/test_dependencies.py
@@ -125,14 +125,14 @@ def test_fetch_dependency_http_error_not_retried(tmp_path: Path) -> None:
         hdrs=None,  # type: ignore[arg-type]
         fp=None,
     )
-    sleep_mock = mock.patch("devservices.utils.retry.time.sleep")
     urlopen_mock = mock.patch(
         "devservices.utils.dependencies.urllib.request.urlopen",
         side_effect=http_error,
     )
-    with sleep_mock as mock_sleep, urlopen_mock, pytest.raises(DependencyError):
+    with urlopen_mock as mock_urlopen, pytest.raises(DependencyError):
         _fetch_dependency(dep, str(tmp_path / "dest"))
-    mock_sleep.assert_not_called()
+    # HTTP errors must not be retried, so urlopen is only ever called once.
+    mock_urlopen.assert_called_once()
 
 
 def test_fetch_dependency_read_error(tmp_path: Path) -> None:

--- a/tests/utils/test_dependencies.py
+++ b/tests/utils/test_dependencies.py
@@ -94,6 +94,46 @@ def test_fetch_dependency_success(tmp_path: Path) -> None:
     assert (Path(dest) / DEVSERVICES_DIR_NAME / CONFIG_FILE_NAME).exists()
 
 
+def test_fetch_dependency_authenticates_with_token(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.setenv("GITHUB_TOKEN", "secret-token")
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    dep = RemoteConfig(
+        repo_name="test-repo",
+        branch="main",
+        repo_link="https://github.com/getsentry/test-repo",
+    )
+    zip_bytes = _make_zip_bytes(BASIC_SERVICE_CONFIG)
+    with mock.patch(
+        "devservices.utils.dependencies.urllib.request.urlopen",
+        return_value=_make_urlopen_response(zip_bytes),
+    ) as urlopen_mock:
+        _fetch_dependency(dep, str(tmp_path / "dest"))
+    req = urlopen_mock.call_args.args[0]
+    assert req.get_header("Authorization") == "Bearer secret-token"
+
+
+def test_fetch_dependency_no_auth_header_without_token(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    dep = RemoteConfig(
+        repo_name="test-repo",
+        branch="main",
+        repo_link="https://github.com/getsentry/test-repo",
+    )
+    zip_bytes = _make_zip_bytes(BASIC_SERVICE_CONFIG)
+    with mock.patch(
+        "devservices.utils.dependencies.urllib.request.urlopen",
+        return_value=_make_urlopen_response(zip_bytes),
+    ) as urlopen_mock:
+        _fetch_dependency(dep, str(tmp_path / "dest"))
+    req = urlopen_mock.call_args.args[0]
+    assert req.get_header("Authorization") is None
+
+
 def test_fetch_dependency_network_error(tmp_path: Path) -> None:
     dep = RemoteConfig(
         repo_name="test-repo",

--- a/tests/utils/test_dependencies.py
+++ b/tests/utils/test_dependencies.py
@@ -68,31 +68,25 @@ def test_fetch_dependency_success(tmp_path: Path) -> None:
     assert (Path(dest) / DEVSERVICES_DIR_NAME / CONFIG_FILE_NAME).exists()
 
 
-def test_fetch_dependency_uses_authenticated_headers(
-    tmp_path: Path,
+def test_fetch_dependency_uses_authenticated_request(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:
+    monkeypatch.setenv("GITHUB_TOKEN", "tok")
     dep = RemoteConfig(
         repo_name="test-repo",
         branch="main",
         repo_link="https://github.com/getsentry/test-repo",
     )
     zip_bytes = _make_zip_bytes(BASIC_SERVICE_CONFIG)
-    with (
-        mock.patch(
-            "devservices.utils.dependencies.github.api_headers",
-            return_value={
-                "Accept": "application/vnd.github+json",
-                "Authorization": "Bearer tok",
-            },
-        ),
-        mock.patch(
-            "devservices.utils.dependencies.urllib.request.urlopen",
-            return_value=_make_urlopen_response(zip_bytes),
-        ) as urlopen_mock,
-    ):
+    with mock.patch(
+        "devservices.utils.dependencies.urllib.request.urlopen",
+        return_value=_make_urlopen_response(zip_bytes),
+    ) as urlopen_mock:
         _fetch_dependency(dep, str(tmp_path / "dest"))
     req = urlopen_mock.call_args.args[0]
-    assert req.get_header("Authorization") == "Bearer tok"
+    # Sent as an unredirected header so it isn't forwarded to the redirect host.
+    assert req.unredirected_hdrs.get("Authorization") == "Bearer tok"
+    assert "Authorization" not in req.headers
 
 
 def test_fetch_dependency_network_error(tmp_path: Path) -> None:

--- a/tests/utils/test_dependencies.py
+++ b/tests/utils/test_dependencies.py
@@ -24,7 +24,6 @@ from devservices.exceptions import ServiceNotFoundError
 from devservices.utils.dependencies import DependencyNode
 from devservices.utils.dependencies import InstalledRemoteDependency
 from devservices.utils.dependencies import _fetch_dependency
-from devservices.utils.dependencies import _parse_github_repo_path
 from devservices.utils.dependencies import construct_dependency_graph
 from devservices.utils.dependencies import get_installed_remote_dependencies
 from devservices.utils.dependencies import get_non_shared_remote_dependencies
@@ -53,31 +52,6 @@ BASIC_SERVICE_CONFIG = {
 INVALID_SERVICE_CONFIG_YAML = "not_a_service_config: true\n"
 
 
-def test_parse_github_repo_path_valid() -> None:
-    assert (
-        _parse_github_repo_path("https://github.com/getsentry/test-repo")
-        == "getsentry/test-repo"
-    )
-    assert (
-        _parse_github_repo_path("https://github.com/getsentry/test-repo.git")
-        == "getsentry/test-repo"
-    )
-    assert (
-        _parse_github_repo_path("https://github.com/getsentry/test-repo/")
-        == "getsentry/test-repo"
-    )
-    assert _parse_github_repo_path("http://github.com/org/repo") == "org/repo"
-
-
-def test_parse_github_repo_path_non_github() -> None:
-    with pytest.raises(ValueError):
-        _parse_github_repo_path("file:///path/to/repo")
-    with pytest.raises(ValueError):
-        _parse_github_repo_path("invalid-link")
-    with pytest.raises(ValueError):
-        _parse_github_repo_path("https://gitlab.com/org/repo")
-
-
 def test_fetch_dependency_success(tmp_path: Path) -> None:
     dep = RemoteConfig(
         repo_name="test-repo",
@@ -94,44 +68,31 @@ def test_fetch_dependency_success(tmp_path: Path) -> None:
     assert (Path(dest) / DEVSERVICES_DIR_NAME / CONFIG_FILE_NAME).exists()
 
 
-def test_fetch_dependency_authenticates_with_token(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+def test_fetch_dependency_uses_authenticated_headers(
+    tmp_path: Path,
 ) -> None:
-    monkeypatch.setenv("GITHUB_TOKEN", "secret-token")
-    monkeypatch.delenv("GH_TOKEN", raising=False)
     dep = RemoteConfig(
         repo_name="test-repo",
         branch="main",
         repo_link="https://github.com/getsentry/test-repo",
     )
     zip_bytes = _make_zip_bytes(BASIC_SERVICE_CONFIG)
-    with mock.patch(
-        "devservices.utils.dependencies.urllib.request.urlopen",
-        return_value=_make_urlopen_response(zip_bytes),
-    ) as urlopen_mock:
+    with (
+        mock.patch(
+            "devservices.utils.dependencies.github.api_headers",
+            return_value={
+                "Accept": "application/vnd.github+json",
+                "Authorization": "Bearer tok",
+            },
+        ),
+        mock.patch(
+            "devservices.utils.dependencies.urllib.request.urlopen",
+            return_value=_make_urlopen_response(zip_bytes),
+        ) as urlopen_mock,
+    ):
         _fetch_dependency(dep, str(tmp_path / "dest"))
     req = urlopen_mock.call_args.args[0]
-    assert req.get_header("Authorization") == "Bearer secret-token"
-
-
-def test_fetch_dependency_no_auth_header_without_token(
-    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
-) -> None:
-    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
-    monkeypatch.delenv("GH_TOKEN", raising=False)
-    dep = RemoteConfig(
-        repo_name="test-repo",
-        branch="main",
-        repo_link="https://github.com/getsentry/test-repo",
-    )
-    zip_bytes = _make_zip_bytes(BASIC_SERVICE_CONFIG)
-    with mock.patch(
-        "devservices.utils.dependencies.urllib.request.urlopen",
-        return_value=_make_urlopen_response(zip_bytes),
-    ) as urlopen_mock:
-        _fetch_dependency(dep, str(tmp_path / "dest"))
-    req = urlopen_mock.call_args.args[0]
-    assert req.get_header("Authorization") is None
+    assert req.get_header("Authorization") == "Bearer tok"
 
 
 def test_fetch_dependency_network_error(tmp_path: Path) -> None:

--- a/tests/utils/test_github.py
+++ b/tests/utils/test_github.py
@@ -40,22 +40,26 @@ def test_zipball_url() -> None:
     )
 
 
-def test_api_headers_with_env_token(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_build_api_request_with_env_token(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setenv("GITHUB_TOKEN", "secret-token")
     monkeypatch.delenv("GH_TOKEN", raising=False)
-    headers = github.api_headers()
-    assert headers["Accept"] == github.GITHUB_API_ACCEPT
-    assert headers["Authorization"] == "Bearer secret-token"
+    req = github.build_api_request("https://api.github.com/x")
+    assert req.get_header("Accept") == github.GITHUB_API_ACCEPT
+    # Token must be an unredirected header so it isn't forwarded on redirect.
+    assert req.unredirected_hdrs.get("Authorization") == "Bearer secret-token"
+    assert "Authorization" not in req.headers
 
 
-def test_api_headers_falls_back_to_gh_token(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_build_api_request_falls_back_to_gh_token(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     monkeypatch.setenv("GH_TOKEN", "gh-env-token")
-    headers = github.api_headers()
-    assert headers["Authorization"] == "Bearer gh-env-token"
+    req = github.build_api_request("https://api.github.com/x")
+    assert req.unredirected_hdrs.get("Authorization") == "Bearer gh-env-token"
 
 
-def test_api_headers_with_gh_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_build_api_request_with_gh_cli(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     monkeypatch.delenv("GH_TOKEN", raising=False)
     with (
@@ -67,11 +71,13 @@ def test_api_headers_with_gh_cli(monkeypatch: pytest.MonkeyPatch) -> None:
             ),
         ),
     ):
-        headers = github.api_headers()
-    assert headers["Authorization"] == "Bearer gh-token"
+        req = github.build_api_request("https://api.github.com/x")
+    assert req.unredirected_hdrs.get("Authorization") == "Bearer gh-token"
 
 
-def test_api_headers_unauthenticated_warns(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_build_api_request_unauthenticated_warns(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
     monkeypatch.delenv("GH_TOKEN", raising=False)
     monkeypatch.setattr("devservices.utils.github._auth_warned", False)
@@ -79,12 +85,12 @@ def test_api_headers_unauthenticated_warns(monkeypatch: pytest.MonkeyPatch) -> N
         mock.patch("devservices.utils.github.shutil.which", return_value=None),
         mock.patch("devservices.utils.github.Console.warning") as warning_mock,
     ):
-        headers = github.api_headers()
-    assert "Authorization" not in headers
+        req = github.build_api_request("https://api.github.com/x")
+    assert req.get_header("Authorization") is None
     warning_mock.assert_called_once()
 
 
-def test_api_headers_gh_cli_not_authenticated(
+def test_build_api_request_gh_cli_not_authenticated(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.delenv("GITHUB_TOKEN", raising=False)
@@ -100,8 +106,8 @@ def test_api_headers_gh_cli_not_authenticated(
         ),
         mock.patch("devservices.utils.github.Console.warning") as warning_mock,
     ):
-        headers = github.api_headers()
-    assert "Authorization" not in headers
+        req = github.build_api_request("https://api.github.com/x")
+    assert req.get_header("Authorization") is None
     warning_mock.assert_called_once()
 
 

--- a/tests/utils/test_github.py
+++ b/tests/utils/test_github.py
@@ -1,6 +1,10 @@
 from __future__ import annotations
 
+import io
+import os
 import subprocess
+import urllib.request
+import zipfile
 from unittest import mock
 
 import pytest
@@ -119,3 +123,23 @@ def test_warn_unauthenticated_only_warns_once(
         github._warn_unauthenticated()
         github._warn_unauthenticated()
     warning_mock.assert_called_once()
+
+
+@pytest.mark.integration
+@pytest.mark.skipif(
+    not os.environ.get("CI"), reason="hits real GitHub; runs in CI only"
+)
+def test_build_api_request_downloads_real_zip() -> None:
+    # End-to-end check that a real zipball download works: the request follows
+    # the api.github.com -> codeload.github.com 302 redirect, and the (possibly
+    # authenticated) Authorization header isn't forwarded in a way that breaks
+    # the download. chartcuterie is a small public repo (~280KB zip).
+    url = github.zipball_url("getsentry/chartcuterie", "master")
+    req = github.build_api_request(url)
+    with urllib.request.urlopen(req) as response:
+        data = response.read()
+    with zipfile.ZipFile(io.BytesIO(data)) as zf:
+        # A valid, non-empty zip with the usual single top-level directory.
+        names = zf.namelist()
+        assert names
+        assert names[0].split("/")[0].startswith("getsentry-chartcuterie-")

--- a/tests/utils/test_github.py
+++ b/tests/utils/test_github.py
@@ -1,0 +1,115 @@
+from __future__ import annotations
+
+import subprocess
+from unittest import mock
+
+import pytest
+
+from devservices.utils import github
+
+
+def test_parse_repo_path_valid() -> None:
+    assert (
+        github.parse_repo_path("https://github.com/getsentry/test-repo")
+        == "getsentry/test-repo"
+    )
+    assert (
+        github.parse_repo_path("https://github.com/getsentry/test-repo.git")
+        == "getsentry/test-repo"
+    )
+    assert (
+        github.parse_repo_path("https://github.com/getsentry/test-repo/")
+        == "getsentry/test-repo"
+    )
+    assert github.parse_repo_path("http://github.com/org/repo") == "org/repo"
+
+
+def test_parse_repo_path_non_github() -> None:
+    with pytest.raises(ValueError):
+        github.parse_repo_path("file:///path/to/repo")
+    with pytest.raises(ValueError):
+        github.parse_repo_path("invalid-link")
+    with pytest.raises(ValueError):
+        github.parse_repo_path("https://gitlab.com/org/repo")
+
+
+def test_zipball_url() -> None:
+    assert (
+        github.zipball_url("getsentry/test-repo", "main")
+        == "https://api.github.com/repos/getsentry/test-repo/zipball/main"
+    )
+
+
+def test_api_headers_with_env_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("GITHUB_TOKEN", "secret-token")
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    headers = github.api_headers()
+    assert headers["Accept"] == github.GITHUB_API_ACCEPT
+    assert headers["Authorization"] == "Bearer secret-token"
+
+
+def test_api_headers_falls_back_to_gh_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.setenv("GH_TOKEN", "gh-env-token")
+    headers = github.api_headers()
+    assert headers["Authorization"] == "Bearer gh-env-token"
+
+
+def test_api_headers_with_gh_cli(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    with (
+        mock.patch("devservices.utils.github.shutil.which", return_value="/usr/bin/gh"),
+        mock.patch(
+            "devservices.utils.github.subprocess.run",
+            return_value=subprocess.CompletedProcess(
+                args=[], returncode=0, stdout="gh-token\n", stderr=""
+            ),
+        ),
+    ):
+        headers = github.api_headers()
+    assert headers["Authorization"] == "Bearer gh-token"
+
+
+def test_api_headers_unauthenticated_warns(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.setattr("devservices.utils.github._auth_warned", False)
+    with (
+        mock.patch("devservices.utils.github.shutil.which", return_value=None),
+        mock.patch("devservices.utils.github.Console.warning") as warning_mock,
+    ):
+        headers = github.api_headers()
+    assert "Authorization" not in headers
+    warning_mock.assert_called_once()
+
+
+def test_api_headers_gh_cli_not_authenticated(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.setattr("devservices.utils.github._auth_warned", False)
+    with (
+        mock.patch("devservices.utils.github.shutil.which", return_value="/usr/bin/gh"),
+        mock.patch(
+            "devservices.utils.github.subprocess.run",
+            return_value=subprocess.CompletedProcess(
+                args=[], returncode=1, stdout="", stderr="not logged in"
+            ),
+        ),
+        mock.patch("devservices.utils.github.Console.warning") as warning_mock,
+    ):
+        headers = github.api_headers()
+    assert "Authorization" not in headers
+    warning_mock.assert_called_once()
+
+
+def test_warn_unauthenticated_only_warns_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setattr("devservices.utils.github._auth_warned", False)
+    with mock.patch("devservices.utils.github.Console.warning") as warning_mock:
+        github._warn_unauthenticated()
+        github._warn_unauthenticated()
+    warning_mock.assert_called_once()


### PR DESCRIPTION
i'm observing occasional fails because our zip downloads are unauthed: https://github.com/getsentry/sentry/actions/runs/27146058496/job/80124077977

this adds authed zip downloads via GH_TOKEN/GITHUB_TOKEN and also falls back to obtaining a token via `gh` cli for local users, and failing that, falls back to unauthed zip downloads with a warning to install `gh` and `gh login`

also moves github things to a github.py to be neat