### PR TITLE
fix: Handle SSH-style GitHub URLs in dependency fetching

### DIFF
--- a/devservices/utils/github.py
+++ b/devservices/utils/github.py
@@ -16,11 +16,17 @@ _auth_warned = False
 
 
 def parse_repo_path(repo_link: str) -> str:
-    """Extract the "owner/repo" path from a GitHub URL."""
+    """Extract the "owner/repo" path from a GitHub URL.
+
+    Handles both HTTPS (https://github.com/owner/repo) and SSH
+    (git@github.com:owner/repo) formats.
+    """
     url = repo_link.rstrip("/").removesuffix(".git")
-    if "github.com/" not in url:
-        raise ValueError(f"Not a GitHub URL: {repo_link}")
-    return url.split("github.com/", 1)[1]
+    if "github.com/" in url:
+        return url.split("github.com/", 1)[1]
+    if "github.com:" in url:
+        return url.split("github.com:", 1)[1]
+    raise ValueError(f"Not a GitHub URL: {repo_link}")
 
 
 def zipball_url(repo_path: str, ref: str) -> str:

--- a/tests/utils/test_github.py
+++ b/tests/utils/test_github.py
@@ -28,6 +28,17 @@ def test_parse_repo_path_valid() -> None:
     assert github.parse_repo_path("http://github.com/org/repo") == "org/repo"
 
 
+def test_parse_repo_path_ssh() -> None:
+    assert (
+        github.parse_repo_path("git@github.com:getsentry/test-repo")
+        == "getsentry/test-repo"
+    )
+    assert (
+        github.parse_repo_path("git@github.com:getsentry/test-repo.git")
+        == "getsentry/test-repo"
+    )
+
+
 def test_parse_repo_path_non_github() -> None:
     with pytest.raises(ValueError):
         github.parse_repo_path("file:///path/to/repo")


### PR DESCRIPTION
`parse_repo_path` only worked on `github.com/` URLs, but not SSH-style `git@github.com:owner/repo` URLs.
This broke `devservices up` for any service whose transitive dependency graph included an SSH URL (currently vroom's reference to `sentry-shared-kafka`).

The parser now also splits on `github.com:` to handle the SSH format.